### PR TITLE
Check accessibility of WORKING AS OF 7 12.HTML

### DIFF
--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -810,47 +810,47 @@ jQuery(document).ready(function($) {
     // Load GMC Terrain feature descriptions from CSV
     var terrainFeatureDescriptions = {};
     function loadTerrainFeatureDescriptions() {
-        var csvUrl = 'https://www.hutchinsonautoteam.com/gmcmodels/gmcterraindescriptions.csv';
+        var csvUrl = 'https://hutchinsonautoteam.com/gmcmodels/gmcterrainfeaturedescriptions.csv';
         console.log('Loading GMC Terrain descriptions from:', csvUrl);
         fetchCsvWithRetry(csvUrl, 'GMC Terrain Feature Descriptions', 3, 1000).then(function(csvText) {
             console.log('GMC Terrain descriptions CSV fetched successfully, length:', csvText.length);
             console.log('First 500 characters of CSV:', csvText.substring(0, 500));
             
-            // Parse the CSV - handle complex format with escaped quotes and multi-line descriptions
+            // Parse the new CSV format with curly braces: {FEATURE_NAME :Description}
             terrainFeatureDescriptions = {};
             
-            // Split by lines and process each line
-            var lines = csvText.split('\n').filter(function(line) { return line.trim(); });
+            // Find all entries enclosed in curly braces
+            var curlyBraceRegex = /\{([^}]+)\}/g;
+            var matches = csvText.match(curlyBraceRegex);
             
-            lines.forEach(function(line, index) {
-                try {
-                    // Each line should be in format: "FEATURE NAME (DESCRIPTION)"
-                    // Handle escaped quotes in feature names (e.g., "19"" becomes 19")
-                    var match = line.match(/^"([^"]*(?:""[^"]*)*)" \((.+)\)$/);
-                    if (match) {
-                        var feature = match[1].replace(/""/g, '"').trim(); // Unescape quotes
-                        var description = match[2].trim(); // Get description
+            if (matches) {
+                matches.forEach(function(match, index) {
+                    try {
+                        // Remove the curly braces and split on the first colon
+                        var content = match.substring(1, match.length - 1); // Remove { and }
+                        var colonIndex = content.indexOf(' :');
                         
-                        // Store with case-insensitive key for matching
-                        terrainFeatureDescriptions[feature.toUpperCase()] = description;
-                        console.log('Loaded GMC Terrain description for:', feature);
-                    } else {
-                        // Try alternative parsing for entries without quotes
-                        var altMatch = line.match(/^([^(]+) \((.+)\)$/);
-                        if (altMatch) {
-                            var feature = altMatch[1].trim();
-                            var description = altMatch[2].trim();
+                        if (colonIndex !== -1) {
+                            var feature = content.substring(0, colonIndex).trim();
+                            var description = content.substring(colonIndex + 2).trim(); // +2 to skip ' :'
                             
-                            terrainFeatureDescriptions[feature.toUpperCase()] = description;
-                            console.log('Loaded GMC Terrain description (alt format) for:', feature);
+                            if (feature && description) {
+                                // Store with case-insensitive key for matching
+                                terrainFeatureDescriptions[feature.toUpperCase()] = description;
+                                console.log('Loaded GMC Terrain description for:', feature);
+                            } else {
+                                console.warn('Empty feature or description:', { feature: feature, description: description.substring(0, 50) + '...' });
+                            }
                         } else {
-                            console.warn('Could not parse terrain description line:', line.substring(0, 100));
+                            console.warn('Could not find colon separator in:', content.substring(0, 100));
                         }
+                    } catch (error) {
+                        console.error('Error parsing terrain description entry:', error, match.substring(0, 100));
                     }
-                } catch (error) {
-                    console.error('Error parsing terrain description line:', error, line.substring(0, 100));
-                }
-            });
+                });
+            } else {
+                console.warn('No curly brace entries found in CSV');
+            }
             
             console.log('GMC Terrain Feature Descriptions loaded, features:', Object.keys(terrainFeatureDescriptions).length);
             console.log('Sample features loaded:', Object.keys(terrainFeatureDescriptions).slice(0, 5));

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -629,6 +629,8 @@ jQuery(document).ready(function($) {
     var terrainHtmlBlockFieldId = 137;
     var acadiaCheckboxFieldId = 130;
     var acadiaHtmlBlockFieldId = 138;
+    var yukonCheckboxFieldId = 131;
+    var yukonHtmlBlockFieldId = 139;
 
     // Global variables
     var vehicleData = null;
@@ -641,6 +643,7 @@ jQuery(document).ready(function($) {
     var trimLevelsData = {};
     var terrainPopulated = false;
     var acadiaPopulated = false;
+    var yukonPopulated = false;
 
     // Model to field ID, CSV URL, and model filter mappings
     var modelConfigs = {
@@ -989,6 +992,68 @@ jQuery(document).ready(function($) {
         }).catch(function(error) {
             console.error('❌ Fetch error for GMC Acadia Feature Descriptions:', error.message);
             acadiaFeatureDescriptions = {};
+            throw error;
+        });
+    }
+
+    // Load GMC Yukon feature descriptions from CSV
+    var yukonFeatureDescriptions = {};
+    function loadYukonFeatureDescriptions() {
+        var csvUrl = 'https://hutchinsonautoteam.com/gmcmodels/gmcyukondescriptions.csv';
+        console.log('Loading GMC Yukon descriptions from:', csvUrl);
+        return fetchCsvWithRetry(csvUrl, 'GMC Yukon Feature Descriptions', 3, 1000).then(function(csvText) {
+            console.log('GMC Yukon descriptions CSV fetched successfully, length:', csvText.length);
+            console.log('First 500 characters of CSV:', csvText.substring(0, 500));
+            
+            // Parse the new CSV format with curly braces: {FEATURE_NAME :Description}
+            yukonFeatureDescriptions = {};
+            
+            // Find all entries enclosed in curly braces - more robust regex
+            var curlyBraceRegex = /\{([^}]+)\}/g;
+            var matches = [];
+            var match;
+            
+            while ((match = curlyBraceRegex.exec(csvText)) !== null) {
+                matches.push(match[1]);
+            }
+            
+            console.log('📊 Found', matches.length, 'GMC Yukon description entries');
+            
+            if (matches.length === 0) {
+                console.warn('❌ No curly brace entries found in GMC Yukon descriptions CSV');
+            }
+            
+            // Parse each feature description
+            matches.forEach(function(match, index) {
+                var separatorIndex = match.indexOf(':');
+                if (separatorIndex === -1) {
+                    console.log('❌ Could not find ":" separator in:', match.substring(0, 100));
+                    return;
+                }
+                
+                var featureName = match.substring(0, separatorIndex).trim();
+                var description = match.substring(separatorIndex + 1).trim();
+                
+                if (featureName && description) {
+                    yukonFeatureDescriptions[featureName.toUpperCase()] = description;
+                    console.log('✅ Loaded GMC Yukon description (alt format) for:', featureName);
+                } else {
+                    console.log('❌ Invalid feature data:', { featureName: featureName, description: description });
+                }
+            });
+            
+            console.log('GMC Yukon Feature Descriptions loaded, features:', Object.keys(yukonFeatureDescriptions).length);
+            console.log('Sample features loaded:', Object.keys(yukonFeatureDescriptions).slice(0, 5));
+            console.log('All yukon features loaded:', Object.keys(yukonFeatureDescriptions));
+            if (Object.keys(yukonFeatureDescriptions).length === 0) {
+                console.warn('❌ No GMC Yukon descriptions were parsed from CSV');
+            } else {
+                console.log('✅ SUCCESS: GMC Yukon descriptions loaded successfully!');
+            }
+            return yukonFeatureDescriptions;
+        }).catch(function(error) {
+            console.error('❌ Fetch error for GMC Yukon Feature Descriptions:', error.message);
+            yukonFeatureDescriptions = {};
             throw error;
         });
     }
@@ -2268,6 +2333,520 @@ function populateTerrainFeaturesAfterDescriptions() {
         trimLevelsData[model] = matchingTrimLevels;
     }
 
+    // Yukon populate functions
+    function populateYukonFeatures() {
+        console.log('=== populateYukonFeatures called ===');
+        console.log('Current yukonPopulated flag:', yukonPopulated);
+        console.log('Form ID:', formId);
+        console.log('yukonHtmlBlockFieldId:', yukonHtmlBlockFieldId);
+        
+        if (yukonPopulated) {
+            console.log('Yukon features already populated, skipping');
+            return;
+        }
+        
+        // Check if descriptions are loaded
+        if (!yukonFeatureDescriptions || Object.keys(yukonFeatureDescriptions).length === 0) {
+            console.log('🚨 Yukon descriptions not loaded, loading first...');
+            // Load descriptions and then populate features
+            loadYukonFeatureDescriptions().then(function() {
+                console.log('✅ Descriptions loaded, now populating features...');
+                populateYukonFeaturesAfterDescriptions();
+            }).catch(function(error) {
+                console.error('❌ Failed to load descriptions:', error);
+                // Continue anyway with basic feature names
+                populateYukonFeaturesAfterDescriptions();
+            });
+            return;
+        }
+        
+        populateYukonFeaturesAfterDescriptions();
+    }
+
+    function populateYukonFeaturesAfterDescriptions() {
+        console.log('=== populateYukonFeaturesAfterDescriptions called ===');
+        
+        var csvUrl = 'https://hutchinsonautoteam.com/gmcmodels/yukon.csv';
+        console.log('Loading yukon features from:', csvUrl);
+        
+        Papa.parse(csvUrl, {
+            download: true,
+            header: true,
+            skipEmptyLines: true,
+            complete: function(results) {
+                console.log('Yukon CSV parsed for population, rows:', results.data.length);
+                console.log('First few rows:', results.data.slice(0, 3));
+                
+                // Parse the CSV data similar to Acadia
+                var featuresByCategory = {};
+                var categories = ['EXTERIOR', 'INTERIOR', 'MECHANICAL', 'SAFETY', 'PACKAGES'];
+                
+                // Process each row to build feature categories
+                results.data.forEach(function(row, rowIndex) {
+                    var trimLevelsCell = row['TRIM LEVELS FOR {EXTERIOR}'] || row['TRIM LEVELS FOR {INTERIOR}'] || row['TRIM LEVELS FOR {MECHANICAL}'] || row['TRIM LEVELS FOR {SAFETY}'] || row['TRIM LEVELS FOR {PACKAGES}'];
+                    
+                    if (trimLevelsCell) {
+                        var categoryMatch = trimLevelsCell.match(/TRIM LEVELS FOR \{([^}]+)\}/);
+                        if (categoryMatch) {
+                            var category = categoryMatch[1];
+                            console.log('Row ' + rowIndex + ': Parsed category:', category);
+                            
+                            // Extract features from this row (all columns except the first)
+                            var features = [];
+                            Object.keys(row).forEach(function(key) {
+                                if (key !== 'TRIM LEVELS FOR {EXTERIOR}' && key !== 'TRIM LEVELS FOR {INTERIOR}' && key !== 'TRIM LEVELS FOR {MECHANICAL}' && key !== 'TRIM LEVELS FOR {SAFETY}' && key !== 'TRIM LEVELS FOR {PACKAGES}' && row[key] && row[key].trim()) {
+                                    features.push(row[key].trim());
+                                }
+                            });
+                            
+                            console.log('Features for ' + category + ':', features.slice(0, 5));
+                            console.log('Raw features before cleaning:', features.slice(0, 5));
+                            
+                            // Clean and store features
+                            var cleanFeatures = features.filter(function(feature) {
+                                return feature && feature.trim() && !feature.match(/^,+$/);
+                            });
+                            
+                            featuresByCategory[category] = cleanFeatures;
+                            console.log('Stored category:', category, 'with', cleanFeatures.length, 'features');
+                        }
+                    }
+                });
+                
+                console.log('Feature groups summary:', Object.keys(featuresByCategory).map(function(cat) {
+                    return cat + ': ' + featuresByCategory[cat].length + ' features';
+                }));
+                
+                // Build HTML for yukon features
+                console.log('Building HTML for yukon features...');
+                var html = '<div class="feature-groups">';
+                var globalIndex = 0;
+                
+                // Initialize global feature mapping
+                if (!window.yukonFeatureMap) {
+                    window.yukonFeatureMap = {};
+                }
+                
+                categories.forEach(function(category) {
+                    if (featuresByCategory[category] && featuresByCategory[category].length > 0) {
+                        console.log('Building HTML for category:', category, 'with', featuresByCategory[category].length, 'features');
+                        
+                        html += '<div class="feature-column">';
+                        html += '<h4>' + category + '</h4>';
+                        html += '<div class="gfield_checkbox">';
+                        
+                        featuresByCategory[category].forEach(function(feature) {
+                            var inputName = 'input_yukon_' + globalIndex;
+                            var simpleValue = 'yukon_feature_' + globalIndex;
+                            
+                            window.yukonFeatureMap[simpleValue] = feature;
+                            
+                            // Try to find the full feature name from yukon descriptions
+                            var fullFeatureName = feature;
+                            if (yukonFeatureDescriptions && Object.keys(yukonFeatureDescriptions).length > 0) {
+                                // First try exact match
+                                var exactMatch = yukonFeatureDescriptions[String(feature).toUpperCase()];
+                                if (exactMatch) {
+                                    fullFeatureName = feature; // Use original since we have exact match
+                                    console.log('✅ Found exact match for:', feature);
+                                } else {
+                                    // Try partial matching for backwards compatibility
+                                    var matchedKey = Object.keys(yukonFeatureDescriptions).find(function(key) {
+                                        return key.includes(String(feature).toUpperCase()) || String(feature).toUpperCase().includes(key);
+                                    });
+                                    if (matchedKey) {
+                                        fullFeatureName = feature; // Keep original name but we have description
+                                        console.log('✅ Found partial match for:', feature);
+                                    } else {
+                                        console.log('❌ No match found for:', feature);
+                                    }
+                                }
+                            } else {
+                                console.log('❌ No match found for:', feature);
+                            }
+                            
+                            html += '<div class="gchoice gchoice_yukon_' + globalIndex + '">';
+                            html += '<input name="' + inputName + '" type="checkbox" value="' + simpleValue + '" data-category="' + category + '" id="choice_3_yukon_' + globalIndex + '">';
+                            html += '<label for="choice_3_yukon_' + globalIndex + '" id="label_yukon_' + globalIndex + '">' + fullFeatureName;
+                            html += ' <span class="feature-info-icon" data-feature="' + feature + '" style="cursor: pointer; color: #007cba; font-weight: bold; margin-left: 5px;" title="Click for feature information">ℹ️</span>';
+                            html += '</label>';
+                            html += '</div>';
+                            
+                            globalIndex++;
+                        });
+                        
+                        html += '</div>';
+                        html += '</div>';
+                    }
+                });
+                
+                html += '</div>';
+                
+                // Add CSS for feature groups layout
+                html += '<style>';
+                html += '.feature-groups { display: flex; flex-wrap: wrap; gap: 20px; }';
+                html += '.feature-column { flex: 1; min-width: 200px; }';
+                html += '.feature-column h4 { margin: 0 0 10px 0; padding: 5px; background: #f0f0f0; border-radius: 4px; }';
+                html += '.gchoice[class*="gchoice_yukon_"] { margin-bottom: 4% !important; padding-bottom: 4px; }';
+                html += '.gfield_checkbox .feature-info-icon { pointer-events: auto !important; }';
+                html += '</style>';
+                
+                console.log('🔨 Generated HTML length:', html.length);
+                console.log('🔨 Generated HTML sample:', html.substring(0, 200) + '...');
+                
+                // Insert the HTML
+                var htmlBlock = $('#field_' + formId + '_' + yukonHtmlBlockFieldId);
+                if (htmlBlock.length) {
+                    console.log('Found HTML block, updating content...');
+                    
+                    // Check for placeholder replacement
+                    var htmlContent = htmlBlock.html();
+                    console.log('📝 HTML Block content before replacement (length: ' + htmlContent.length + '):', htmlContent);
+                    console.log('🔍 Looking for placeholder: {yukon feature checkboxes}');
+                    console.log('🔍 Placeholder found:', htmlContent.indexOf('{yukon feature checkboxes}') !== -1);
+                    
+                    if (htmlContent.indexOf('{yukon feature checkboxes}') !== -1) {
+                        htmlContent = htmlContent.replace('{yukon feature checkboxes}', html);
+                        htmlBlock.html(htmlContent);
+                        console.log('✅ Replaced {yukon feature checkboxes} placeholder in field 139');
+                    } else {
+                        // If no placeholder found, replace entire content
+                        htmlBlock.html(html);
+                        console.log('⚠️ No placeholder found, replaced entire HTML block content');
+                    }
+                    
+                    console.log('HTML block updated');
+                    
+                    // Mark as populated
+                    yukonPopulated = true;
+                    console.log('✅ Yukon features populated successfully!');
+                    
+                    // Store the CSV data for trim level matching
+                    var yukonCsvData = results.data;
+                    
+                    // Initial trim level check (no features selected)
+                    checkYukonMatchingTrimLevels(yukonCsvData);
+                    
+                    // Bind change events
+                    htmlBlock.find('input[type="checkbox"]').on('change', function() {
+                        var featureValue = this.value;
+                        var featureName = window.yukonFeatureMap[featureValue];
+                        var category = $(this).data('category');
+                        console.log('YUKON feature changed:', featureName, 'Category:', category, 'Checked:', this.checked);
+                        
+                        // Check for matching trim levels
+                        checkYukonMatchingTrimLevels(yukonCsvData);
+                    });
+
+                    htmlBlock.find('.feature-info-icon').off('click.featureInfo').on('click.featureInfo', function(e) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        var feature = $(this).attr('data-feature');
+                        console.log('=== YUKON FEATURE INFO ICON CLICKED ===');
+                        console.log('Feature clicked:', feature);
+                        console.log('Feature type:', typeof feature);
+                        console.log('Feature length:', feature ? feature.length : 'undefined');
+                        console.log('Available yukon descriptions:', Object.keys(yukonFeatureDescriptions));
+                        console.log('Total descriptions available:', Object.keys(yukonFeatureDescriptions).length);
+                        console.log('All descriptions:', yukonFeatureDescriptions);
+                        
+                        // Handle case where feature might be undefined or not a string
+                        if (!feature || typeof feature !== 'string') {
+                            console.error('Invalid feature:', feature);
+                            showFeatureDescription('Unknown Feature', 'Feature information not available');
+                            return;
+                        }
+                        
+                        console.log('Looking for feature (uppercase):', feature.toUpperCase());
+                        
+                        // Normalize feature name to handle common typos
+                        function normalizeFeatureName(featureName) {
+                            return featureName
+                                .replace(/INFOTAINTMENT/g, 'INFOTAINMENT')  // Fix common typo
+                                .replace(/\s+/g, ' ')                       // Normalize whitespace
+                                .trim();
+                        }
+                        
+                        var normalizedFeature = normalizeFeatureName(feature.toUpperCase());
+                        console.log('Normalized feature:', normalizedFeature);
+                        
+                        // Try exact match first with normalized feature
+                        var description = yukonFeatureDescriptions[normalizedFeature];
+                        if (description) {
+                            console.log('✅ Found exact match with normalized feature:', normalizedFeature);
+                        }
+                        
+                        // If no exact match, try with original feature name
+                        if (!description) {
+                            description = yukonFeatureDescriptions[feature.toUpperCase()];
+                            if (description) {
+                                console.log('✅ Found exact match with original feature:', feature.toUpperCase());
+                            }
+                        }
+                        
+                        // If still no match, try partial matching with normalized names
+                        if (!description) {
+                            console.log('No exact match found, trying partial matching...');
+                            console.log('Searching for normalized feature:', normalizedFeature);
+                            var matchedKey = Object.keys(yukonFeatureDescriptions).find(function(key) {
+                                var normalizedKey = normalizeFeatureName(key);
+                                var keyContainsFeature = normalizedKey.includes(normalizedFeature);
+                                var featureContainsKey = normalizedFeature.includes(normalizedKey);
+                                
+                                if (keyContainsFeature || featureContainsKey) {
+                                    console.log('Partial match candidate:', key, '(normalized:', normalizedKey, ')');
+                                    return true;
+                                }
+                                return false;
+                            });
+                            if (matchedKey) {
+                                description = yukonFeatureDescriptions[matchedKey];
+                                console.log('✅ Found partial match:', matchedKey);
+                            } else {
+                                console.log('❌ No partial match found');
+                            }
+                        }
+                        
+                        // If still no match, provide fallback
+                        if (!description) {
+                            description = 'No GMC Yukon description available for ' + feature;
+                            console.log('No match found, using fallback description');
+                        }
+                        
+                        console.log('Found description:', description);
+                        console.log('=== END YUKON FEATURE INFO DEBUG ===');
+                        
+                        showFeatureDescription(feature, description);
+                    });
+                } else {
+                    console.error('❌ HTML block not found for field ID:', yukonHtmlBlockFieldId);
+                }
+            },
+            error: function(error) {
+                console.error('❌ Error parsing Yukon CSV:', error);
+            }
+        });
+    }
+
+    // Check for matching Yukon trim levels
+    function checkYukonMatchingTrimLevels(csvData) {
+        var model = 'YUKON';
+        var trimLevels = ['AT4', 'DENALI', 'ELEVATION', 'AT4 ULTIMATE', 'DENALI ULTIMATE'];
+        var htmlBlockFieldId = 69; // Field ID for {TRIM LEVELS} replacement
+        
+        // Get selected features
+        var selectedFeatures = [];
+        $('#field_' + formId + '_' + yukonHtmlBlockFieldId + ' input[type="checkbox"]:checked').each(function() {
+            var featureValue = $(this).val();
+            var featureName = window.yukonFeatureMap[featureValue];
+            if (featureName) {
+                selectedFeatures.push(featureName);
+            }
+        });
+        
+        console.log('Selected YUKON features:', selectedFeatures);
+        
+        if (selectedFeatures.length === 0) {
+            $('#field_' + formId + '_' + htmlBlockFieldId).html('<p>Select features to see matching trim levels</p>');
+            return;
+        }
+        
+        var matchingTrimLevels = [];
+        var categories = ['EXTERIOR', 'INTERIOR', 'MECHANICAL', 'SAFETY', 'PACKAGES'];
+        var featureToColumnMap = {};
+        var featureToCategoryMap = {};
+        var trimLevelRows = {};
+        var trimLevelRowsByCategory = {};
+        var currentCategory = null;
+        
+        // Parse the CSV data to map features to columns and find trim level rows
+        csvData.forEach(function(row, rowIndex) {
+            var trimLevelsCell = row['TRIM LEVELS FOR {EXTERIOR}'] || row['TRIM LEVELS FOR {INTERIOR}'] || row['TRIM LEVELS FOR {MECHANICAL}'] || row['TRIM LEVELS FOR {SAFETY}'] || row['TRIM LEVELS FOR {PACKAGES}'];
+            
+            if (trimLevelsCell) {
+                var categoryMatch = trimLevelsCell.match(/TRIM LEVELS FOR \{([^}]+)\}/);
+                if (categoryMatch) {
+                    currentCategory = categoryMatch[1];
+                    console.log('YUKON Processing category:', currentCategory);
+                    trimLevelRowsByCategory[currentCategory] = {};
+                    
+                    // Map features to column indices for this category
+                    var columnIndex = 0;
+                    Object.keys(row).forEach(function(key) {
+                        if (key !== 'TRIM LEVELS FOR {EXTERIOR}' && key !== 'TRIM LEVELS FOR {INTERIOR}' && key !== 'TRIM LEVELS FOR {MECHANICAL}' && key !== 'TRIM LEVELS FOR {SAFETY}' && key !== 'TRIM LEVELS FOR {PACKAGES}' && row[key] && row[key].trim()) {
+                            var feature = row[key].trim();
+                            if (feature && !feature.match(/^,+$/)) {
+                                featureToColumnMap[feature] = columnIndex;
+                                featureToCategoryMap[feature] = currentCategory;
+                                columnIndex++;
+                            }
+                        }
+                    });
+                }
+            } else {
+                // Check if this row contains trim level data
+                var firstCell = Object.values(row)[0];
+                if (firstCell && trimLevels.some(function(level) {
+                    return firstCell.includes(level);
+                })) {
+                    var trimLevel = null;
+                    trimLevels.forEach(function(level) {
+                        if (firstCell.includes(level)) {
+                            trimLevel = level;
+                        }
+                    });
+                    
+                    if (trimLevel) {
+                        console.log('YUKON Found trim level row:', trimLevel);
+                        var rowValues = Object.values(row);
+                        trimLevelRows[trimLevel] = rowValues;
+                        
+                        // Also store by category if we have a current category
+                        if (currentCategory) {
+                            if (!trimLevelRowsByCategory[currentCategory]) {
+                                trimLevelRowsByCategory[currentCategory] = {};
+                            }
+                            trimLevelRowsByCategory[currentCategory][trimLevel] = rowValues;
+                        }
+                    }
+                }
+            }
+        });
+        
+        console.log('YUKON Feature to column mapping:', featureToColumnMap);
+        console.log('YUKON Feature to category mapping:', featureToCategoryMap);
+        console.log('YUKON Trim level rows:', Object.keys(trimLevelRows));
+        
+        // Check each trim level
+        trimLevels.forEach(function(trimLevel) {
+            if (trimLevelRows[trimLevel]) {
+                var hasAllFeatures = true;
+                var featureResults = [];
+                
+                selectedFeatures.forEach(function(feature) {
+                    var columnIndex = featureToColumnMap[feature];
+                    var matchedFeature = feature;
+                    
+                    // If exact match not found, try fuzzy matching
+                    if (columnIndex === undefined) {
+                        console.log('YUKON Feature "' + feature + '" not found in column mapping, trying fuzzy matching...');
+                        var bestMatch = null;
+                        var bestSimilarity = 0;
+                        
+                        Object.keys(featureToColumnMap).forEach(function(csvFeature) {
+                            var similarity = fuzzyMatch(csvFeature, feature, model, feature);
+                            if (similarity > bestSimilarity && similarity > 0.5) {
+                                bestMatch = csvFeature;
+                                bestSimilarity = similarity;
+                            }
+                        });
+                        
+                        if (bestMatch) {
+                            columnIndex = featureToColumnMap[bestMatch];
+                            matchedFeature = bestMatch;
+                            console.log('Found YUKON fuzzy match for "' + feature + '": "' + bestMatch + '" (similarity: ' + bestSimilarity + ')');
+                        }
+                    }
+                    
+                    if (columnIndex !== undefined) {
+                        var value = '';
+                        var featureCategory = featureToCategoryMap[matchedFeature];
+                        
+                        // Try to get value from category-specific storage first
+                        if (featureCategory && trimLevelRowsByCategory[featureCategory] && trimLevelRowsByCategory[featureCategory][trimLevel]) {
+                            value = trimLevelRowsByCategory[featureCategory][trimLevel][columnIndex];
+                        } else {
+                            // Fall back to global storage
+                            value = trimLevelRows[trimLevel][columnIndex];
+                        }
+                        
+                        var hasFeature = value && (value.trim().toUpperCase() === 'YES' || value.trim().toUpperCase() === 'Y');
+                        featureResults.push({
+                            feature: feature,
+                            matchedFeature: matchedFeature,
+                            value: value,
+                            hasFeature: hasFeature,
+                            column: columnIndex,
+                            category: featureCategory
+                        });
+                        
+                        if (!hasFeature) {
+                            hasAllFeatures = false;
+                        }
+                    } else {
+                        console.warn('YUKON Feature "' + feature + '" not found in CSV columns');
+                        hasAllFeatures = false;
+                    }
+                });
+                
+                if (hasAllFeatures) {
+                    matchingTrimLevels.push(trimLevel);
+                }
+                
+                console.log('YUKON Trim level ' + trimLevel + ' has all features: ' + hasAllFeatures);
+                console.log('YUKON Feature results for ' + trimLevel + ':', featureResults);
+            }
+        });
+        
+        console.log('YUKON Matching trim levels:', matchingTrimLevels);
+        
+        // Update the HTML block with matching trim levels
+        var htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
+        if (htmlBlock.length) {
+            if (matchingTrimLevels.length > 0) {
+                var trimLevelText = matchingTrimLevels.join(', ');
+                var html = '<p>Wonderful, it sounds like the <strong>' + trimLevelText + '</strong> would be the best fit, which has all of these features and it is available! One moment while I plug this car in.</p>';
+                html += '<button id="viewYukonTrimLevelsButton" style="margin-top: 10px; padding: 8px 16px; background-color: #007cba; color: white; border: none; border-radius: 4px; cursor: pointer;">View Trim Levels</button>';
+                htmlBlock.html(html);
+                
+                // Bind click event for trim levels button
+                $('#viewYukonTrimLevelsButton').off('click').on('click', function(e) {
+                    e.preventDefault();
+                    
+                    // Prevent multiple rapid clicks
+                    var button = $(this);
+                    if (button.data('loading')) {
+                        console.log('YUKON View Trim Levels button already loading, ignoring click');
+                        return;
+                    }
+                    
+                    button.data('loading', true);
+                    button.prop('disabled', true);
+                    var originalText = button.text();
+                    button.text('Loading...');
+                    
+                    console.log('YUKON View Trim Levels button clicked');
+                    console.log('YUKON Trim levels data:', {
+                        model: model,
+                        matchingTrimLevels: matchingTrimLevels,
+                        modelFilter: model
+                    });
+                    
+                    try {
+                        showTrimLevelsPopup(model, matchingTrimLevels, model);
+                    } catch (error) {
+                        console.error('Error showing YUKON trim levels popup:', error);
+                        alert('Error: Unable to open trim levels popup. Please try again.');
+                    }
+                    
+                    // Reset button state after a delay
+                    setTimeout(function() {
+                        button.data('loading', false);
+                        button.prop('disabled', false);
+                        button.text(originalText);
+                    }, 2000);
+                });
+            } else {
+                htmlBlock.html('<p>No matching trim levels found. Please adjust your feature selections.</p>');
+            }
+        } else {
+            console.error('❌ HTML block not found for field ID:', htmlBlockFieldId);
+        }
+        
+        // Store the results
+        trimLevelsData[model] = matchingTrimLevels;
+    }
+
 	function updateTrimLevels(model) {
     var config = modelConfigs[model];
     if (!config) {
@@ -2315,6 +2894,29 @@ function populateTerrainFeaturesAfterDescriptions() {
             acadiaHtmlBlockFieldId: acadiaHtmlBlockFieldId,
             selector1: '#field_' + formId + '_' + acadiaHtmlBlockFieldId,
             selector2: '#field_' + formId + '_138',
+            found: checkboxField.length,
+            actualId: checkboxField.attr('id'),
+            hasCheckboxes: checkboxField.find('input[type="checkbox"]').length
+        });
+        
+        htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
+        trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
+    } else if (model === 'YUKON') {
+        // For YUKON, checkboxes are in field 139 (HTML block)
+        checkboxField = $('#field_' + formId + '_' + yukonHtmlBlockFieldId);
+        if (!checkboxField.length) {
+            checkboxField = $('#field_' + formId + '_139');
+        }
+        if (!checkboxField.length) {
+            checkboxField = $('[id*="139"]').filter(function() {
+                return $(this).attr('id').includes('field') || $(this).attr('id').includes('input');
+            });
+        }
+        
+        console.log('YUKON checkboxField debug:', {
+            yukonHtmlBlockFieldId: yukonHtmlBlockFieldId,
+            selector1: '#field_' + formId + '_' + yukonHtmlBlockFieldId,
+            selector2: '#field_' + formId + '_139',
             found: checkboxField.length,
             actualId: checkboxField.attr('id'),
             hasCheckboxes: checkboxField.find('input[type="checkbox"]').length
@@ -2399,6 +3001,35 @@ function populateTerrainFeaturesAfterDescriptions() {
             if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
                 $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
                 console.log('Prepended info icon before ACADIA feature: ' + feature + ', matched: ' + matchedFeature);
+            }
+        });
+    } else if (model === 'YUKON') {
+        // For YUKON, handle the different structure
+        checkboxField.find('.gchoice').each(function() {
+            var $div = $(this);
+            var $input = $div.find('input[type="checkbox"]');
+            var $label = $div.find('label');
+            var feature = $input.attr('value') || '';
+            
+            if (!feature || !$input.length) {
+                console.warn('Invalid YUKON checkbox structure in field (ID: ' + yukonHtmlBlockFieldId + ')', {
+                    feature: feature,
+                    inputExists: $input.length > 0,
+                    labelExists: $label.length > 0,
+                    divHtml: $div.html(),
+                    inputId: $input.attr('id'),
+                    labelClasses: $label.attr('class'),
+                    parentClasses: $div.attr('class')
+                });
+                return;
+            }
+            
+            var matchedFeature = Object.keys(featureDescriptions).find(function(key) {
+                return fuzzyMatch(key, feature, model, feature);
+            });
+            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
+                $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
+                console.log('Prepended info icon before YUKON feature: ' + feature + ', matched: ' + matchedFeature);
             }
         });
     } else {
@@ -2505,6 +3136,39 @@ function populateTerrainFeaturesAfterDescriptions() {
             // If still no match, provide fallback
             if (!description) {
                 description = 'No GMC Acadia description available for ' + featureString;
+                console.log('No match found, using fallback description');
+            }
+            
+            console.log('Found description:', description);
+        } else if (model === 'YUKON') {
+            console.log('YUKON model detected, using GMC descriptions');
+            console.log('Feature to lookup:', feature);
+            
+            // Convert feature to string to avoid toUpperCase errors
+            var featureString = String(feature || '');
+            console.log('Feature as string:', featureString);
+            console.log('Feature uppercase:', featureString.toUpperCase());
+            console.log('Available yukon descriptions:', Object.keys(yukonFeatureDescriptions));
+            
+            // Try exact match first
+            description = yukonFeatureDescriptions[featureString.toUpperCase()];
+            
+            // If no exact match, try partial matching
+            if (!description) {
+                console.log('No exact match found, trying partial matching...');
+                var matchedKey = Object.keys(yukonFeatureDescriptions).find(function(key) {
+                    // Check if the key contains the feature or vice versa
+                    return key.includes(featureString.toUpperCase()) || featureString.toUpperCase().includes(key);
+                });
+                if (matchedKey) {
+                    description = yukonFeatureDescriptions[matchedKey];
+                    console.log('Found partial match:', matchedKey);
+                }
+            }
+            
+            // If still no match, provide fallback
+            if (!description) {
+                description = 'No GMC Yukon description available for ' + featureString;
                 console.log('No match found, using fallback description');
             }
             
@@ -3314,10 +3978,18 @@ function initFormBindings() {
                                     populateAcadiaFeatures();
                                     console.log('acadiaPopulated after call:', acadiaPopulated);
                                     updateTrimLevels('ACADIA');
+                                } else if (input.val() === 'YUKON' && input.is(':checked')) {
+                                    console.log('🚗 YUKON selected via radio button - calling populateYukonFeatures');
+                                    console.log('Current time:', new Date().toISOString());
+                                    console.log('yukonPopulated before call:', yukonPopulated);
+                                    populateYukonFeatures();
+                                    console.log('yukonPopulated after call:', yukonPopulated);
+                                    updateTrimLevels('YUKON');
                                 } else if (input.is(':checked')) {
-                                    console.log('Non-TERRAIN/ACADIA GMC model selected: ' + input.val());
+                                    console.log('Non-TERRAIN/ACADIA/YUKON GMC model selected: ' + input.val());
                                     terrainPopulated = false;
                                     acadiaPopulated = false;
+                                    yukonPopulated = false;
                                 }
                             }
                         }
@@ -3374,10 +4046,18 @@ function initFormBindings() {
                              populateAcadiaFeatures();
                              console.log('acadiaPopulated after call:', acadiaPopulated);
                              updateTrimLevels('ACADIA');
+                         } else if ($(this).val() === 'YUKON' && $(this).is(':checked')) {
+                             console.log('🚗 YUKON selected via delegated radio button - calling populateYukonFeatures');
+                             console.log('Current time:', new Date().toISOString());
+                             console.log('yukonPopulated before call:', yukonPopulated);
+                             populateYukonFeatures();
+                             console.log('yukonPopulated after call:', yukonPopulated);
+                             updateTrimLevels('YUKON');
                          } else if ($(this).is(':checked')) {
-                             console.log('Non-TERRAIN/ACADIA GMC model selected via delegated: ' + $(this).val());
+                             console.log('Non-TERRAIN/ACADIA/YUKON GMC model selected via delegated: ' + $(this).val());
                              terrainPopulated = false;
                              acadiaPopulated = false;
+                             yukonPopulated = false;
                          }
                      }
                 }
@@ -3529,10 +4209,15 @@ function initFormBindings() {
                 console.log('ACADIA radio button detected, calling populateAcadiaFeatures');
                 populateAcadiaFeatures();
                 updateTrimLevels('ACADIA');
+            } else if ($(this).val() === 'YUKON' && $(this).is(':checked')) {
+                console.log('YUKON radio button detected, calling populateYukonFeatures');
+                populateYukonFeatures();
+                updateTrimLevels('YUKON');
             } else if ($(this).is(':checked')) {
-                console.log('Non-TERRAIN/ACADIA GMC model selected, resetting');
+                console.log('Non-TERRAIN/ACADIA/YUKON GMC model selected, resetting');
                 terrainPopulated = false;
                 acadiaPopulated = false;
+                yukonPopulated = false;
             }
         });
 
@@ -3565,7 +4250,17 @@ function initFormBindings() {
                             } else {
                                 console.log('ACADIA radio button not checked or not found');
                             }
-                        } else if (model !== 'TERRAIN' && model !== 'ACADIA') {
+                        } else if (model === 'YUKON') {
+                            // Check if YUKON radio button is selected
+                            var yukonRadio = $('#field_' + formId + '_' + gmcModelFieldId + ' input[type="radio"][value="YUKON"]');
+                            if (yukonRadio.length && yukonRadio.is(':checked')) {
+                                console.log('YUKON radio button is checked, populating features');
+                                populateYukonFeatures();
+                                updateTrimLevels(model);
+                            } else {
+                                console.log('YUKON radio button not checked or not found');
+                            }
+                        } else if (model !== 'TERRAIN' && model !== 'ACADIA' && model !== 'YUKON') {
                             updateTrimLevels(model);
                         }
                     });
@@ -5716,6 +6411,7 @@ function showVehicleInfo(isKiaField) {
     loadFeatureDescriptions();
     loadTerrainFeatureDescriptions();
     loadAcadiaFeatureDescriptions();
+    loadYukonFeatureDescriptions();
 initFormBindings();
 updateSelectedName();
 

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -1188,11 +1188,22 @@ function populateTerrainFeaturesAfterDescriptions() {
                         // Try to find the full feature name from terrain descriptions
                         var fullFeatureName = feature;
                         if (terrainFeatureDescriptions && Object.keys(terrainFeatureDescriptions).length > 0) {
-                            var matchedKey = Object.keys(terrainFeatureDescriptions).find(function(key) {
-                                return key.includes(String(feature).toUpperCase()) || String(feature).toUpperCase().includes(key);
-                            });
-                            if (matchedKey) {
-                                fullFeatureName = matchedKey;
+                            // First try exact match
+                            var exactMatch = terrainFeatureDescriptions[String(feature).toUpperCase()];
+                            if (exactMatch) {
+                                fullFeatureName = feature; // Use original since we have exact match
+                                console.log('✅ Found exact match for:', feature);
+                            } else {
+                                // Try partial matching for backwards compatibility
+                                var matchedKey = Object.keys(terrainFeatureDescriptions).find(function(key) {
+                                    return key.includes(String(feature).toUpperCase()) || String(feature).toUpperCase().includes(key);
+                                });
+                                if (matchedKey) {
+                                    fullFeatureName = matchedKey;
+                                    console.log('⚠️ Found partial match for:', feature, '→', matchedKey);
+                                } else {
+                                    console.log('❌ No match found for:', feature);
+                                }
                             }
                         }
                         

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -2157,9 +2157,41 @@ function populateTerrainFeaturesAfterDescriptions() {
                 htmlBlock.html(html);
                 
                 // Bind click event for trim levels button
-                $('#viewAcadiaTrimLevelsButton').off('click').on('click', function() {
+                $('#viewAcadiaTrimLevelsButton').off('click').on('click', function(e) {
+                    e.preventDefault();
+                    
+                    // Prevent multiple rapid clicks
+                    var button = $(this);
+                    if (button.data('loading')) {
+                        console.log('ACADIA View Trim Levels button already loading, ignoring click');
+                        return;
+                    }
+                    
+                    button.data('loading', true);
+                    button.prop('disabled', true);
+                    var originalText = button.text();
+                    button.text('Loading...');
+                    
                     console.log('ACADIA View Trim Levels button clicked');
-                    showTrimLevelsPopup(model, matchingTrimLevels, model);
+                    console.log('ACADIA Trim levels data:', {
+                        model: model,
+                        matchingTrimLevels: matchingTrimLevels,
+                        modelFilter: model
+                    });
+                    
+                    try {
+                        showTrimLevelsPopup(model, matchingTrimLevels, model);
+                    } catch (error) {
+                        console.error('Error showing ACADIA trim levels popup:', error);
+                        alert('Error: Unable to open trim levels popup. Please try again.');
+                    }
+                    
+                    // Reset button state after a delay
+                    setTimeout(function() {
+                        button.data('loading', false);
+                        button.prop('disabled', false);
+                        button.text(originalText);
+                    }, 2000);
                 });
             } else {
                 htmlBlock.html('<p>No matching trim levels found. Please adjust your feature selections.</p>');
@@ -3798,14 +3830,15 @@ function initFormBindings() {
      * Meets line requirement.
      */
 	function showTrimLevelsPopup(model, trimLevels, modelFilter) {
-    $('#trimLevelsPopup, #trimLevelsOverlay').remove();
+    try {
+        $('#trimLevelsPopup, #trimLevelsOverlay').remove();
 
-    // Safety check for parameters
-    if (!model) {
-        console.error('showTrimLevelsPopup: model parameter is required');
-        alert('Error: Model information is missing. Please refresh the page and try again.');
-        return;
-    }
+        // Safety check for parameters
+        if (!model) {
+            console.error('showTrimLevelsPopup: model parameter is required');
+            alert('Error: Model information is missing. Please refresh the page and try again.');
+            return;
+        }
     
     if (!Array.isArray(trimLevels) || trimLevels.length === 0) {
         console.error('showTrimLevelsPopup: trimLevels must be a non-empty array', {
@@ -4025,13 +4058,116 @@ function initFormBindings() {
             },
             error: function(error) {
                 console.error('Papa Parse error for New Inventory CSV: ' + error);
-                alert('Error: Failed to parse new inventory data. Please contact support.');
+                console.error('CSV parsing failed for trim levels popup');
+                
+                // Create a fallback popup with error message
+                var fallbackPopupHtml = '\
+                    <div id="trimLevelsPopup">\
+                        <div id="trimLevelsPopupContent">\
+                            <div class="trim-header">\
+                                <h2>Trim Levels for ' + modelFilter + '</h2>\
+                            </div>\
+                            <div style="padding: 20px; text-align: center;">\
+                                <p style="margin-bottom: 20px;">⚠️ Unable to parse inventory data at this time.</p>\
+                                <p style="margin-bottom: 20px;">The following trim levels are available for your selected features:</p>\
+                                <ul style="list-style: none; padding: 0; margin: 0;">' +
+                                    trimLevels.map(function(trim) {
+                                        return '<li style="padding: 8px; margin: 4px 0; background: #f0f0f0; border-radius: 4px;"><strong>' + trim + '</strong></li>';
+                                    }).join('') +
+                                '</ul>\
+                                <p style="margin-top: 20px; font-size: 0.9em; color: #666;">Please contact us directly for current inventory availability.</p>\
+                            </div>\
+                        </div>\
+                        <button type="button" class="trim-close-popup">Close</button>\
+                    </div>\
+                    <div id="trimLevelsOverlay"></div>';
+                
+                $('body').append(fallbackPopupHtml);
+                
+                var popup = $('#trimLevelsPopup');
+                var overlay = $('#trimLevelsOverlay');
+                
+                // Add event handlers for the fallback popup
+                var popupCreationTime = Date.now();
+                setTimeout(function() {
+                    overlay.on('click', function(e) {
+                        var timeSinceCreation = Date.now() - popupCreationTime;
+                        if (e.target.id === 'trimLevelsOverlay' && timeSinceCreation > 300) {
+                            console.log('Fallback trim levels overlay clicked (parse error), closing popup');
+                            $('#trimLevelsPopup, #trimLevelsOverlay').remove();
+                        }
+                    });
+                }, 100);
+                
+                popup.find('.trim-close-popup').on('click', function() {
+                    console.log('Fallback trim levels close button clicked (parse error), closing popup');
+                    $('#trimLevelsPopup, #trimLevelsOverlay').remove();
+                });
+                
+                console.log('Fallback trim levels popup created for ' + model + ' due to CSV parse error');
             }
         });
     }).catch(function(error) {
         console.error('Fetch error for New Inventory CSV: ' + error.message);
-        alert('Error: Unable to load new inventory data. Please check the CSV file at ' + csvUrl + ' or contact support.');
+        console.error('Full error object:', error);
+        
+        // Create a fallback popup with error message
+        var fallbackPopupHtml = '\
+            <div id="trimLevelsPopup">\
+                <div id="trimLevelsPopupContent">\
+                    <div class="trim-header">\
+                        <h2>Trim Levels for ' + modelFilter + '</h2>\
+                    </div>\
+                    <div style="padding: 20px; text-align: center;">\
+                        <p style="margin-bottom: 20px;">⚠️ Unable to load inventory data at this time.</p>\
+                        <p style="margin-bottom: 20px;">The following trim levels are available for your selected features:</p>\
+                        <ul style="list-style: none; padding: 0; margin: 0;">' +
+                            trimLevels.map(function(trim) {
+                                return '<li style="padding: 8px; margin: 4px 0; background: #f0f0f0; border-radius: 4px;"><strong>' + trim + '</strong></li>';
+                            }).join('') +
+                        '</ul>\
+                        <p style="margin-top: 20px; font-size: 0.9em; color: #666;">Please contact us directly for current inventory availability.</p>\
+                    </div>\
+                </div>\
+                <button type="button" class="trim-close-popup">Close</button>\
+            </div>\
+            <div id="trimLevelsOverlay"></div>';
+        
+        $('body').append(fallbackPopupHtml);
+        
+        var popup = $('#trimLevelsPopup');
+        var overlay = $('#trimLevelsOverlay');
+        
+        // Add event handlers for the fallback popup
+        var popupCreationTime = Date.now();
+        setTimeout(function() {
+            overlay.on('click', function(e) {
+                var timeSinceCreation = Date.now() - popupCreationTime;
+                if (e.target.id === 'trimLevelsOverlay' && timeSinceCreation > 300) {
+                    console.log('Fallback trim levels overlay clicked, closing popup');
+                    $('#trimLevelsPopup, #trimLevelsOverlay').remove();
+                }
+            });
+        }, 100);
+        
+        popup.find('.trim-close-popup').on('click', function() {
+            console.log('Fallback trim levels close button clicked, closing popup');
+            $('#trimLevelsPopup, #trimLevelsOverlay').remove();
+        });
+        
+                 console.log('Fallback trim levels popup created for ' + model + ' due to CSV fetch error');
     });
+    
+    } catch (globalError) {
+        console.error('Critical error in showTrimLevelsPopup:', globalError);
+        console.error('Parameters:', { model: model, trimLevels: trimLevels, modelFilter: modelFilter });
+        
+        // Remove any existing popups
+        $('#trimLevelsPopup, #trimLevelsOverlay').remove();
+        
+        // Show a simple error message
+        alert('Error: Unable to display trim levels popup. Please try again or contact support.');
+    }
 }
 
 function sortTable(columnIndex, isAsc) {

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -810,7 +810,7 @@ jQuery(document).ready(function($) {
     // Load GMC Terrain feature descriptions from CSV
     var terrainFeatureDescriptions = {};
     function loadTerrainFeatureDescriptions() {
-        var csvUrl = 'https://hutchinsonautoteam.com/gmcmodels/gmcterrainfeaturedescriptions.csv';
+        var csvUrl = 'https://hutchinsonautoteam.com/gmcmodels/gmcterrainfeaturedescriptions.CSV';
         console.log('Loading GMC Terrain descriptions from:', csvUrl);
         fetchCsvWithRetry(csvUrl, 'GMC Terrain Feature Descriptions', 3, 1000).then(function(csvText) {
             console.log('GMC Terrain descriptions CSV fetched successfully, length:', csvText.length);
@@ -5000,7 +5000,14 @@ window.testTerrainDescriptions = function() {
     loadTerrainFeatureDescriptions();
 };
 
-console.log('Debug functions available: testTerrainDebug(), forcePopulateTerrainFeatures(), createTerrainCheckboxesManually(), checkTerrainState(), testTerrainDescriptions()');
+// Force reload terrain descriptions
+window.reloadTerrainDescriptions = function() {
+    console.log('🔄 Forcing reload of terrain descriptions...');
+    terrainFeatureDescriptions = {};
+    loadTerrainFeatureDescriptions();
+};
+
+console.log('Debug functions available: testTerrainDebug(), forcePopulateTerrainFeatures(), createTerrainCheckboxesManually(), checkTerrainState(), testTerrainDescriptions(), reloadTerrainDescriptions()');
 
 // GLOBAL RADIO BUTTON LISTENER FOR DEBUGGING
 $(document).on('change', 'input[type="radio"]', function() {

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -1112,8 +1112,10 @@ jQuery(document).ready(function($) {
                             currentCategory = firstCell.match(/\{(.+)\}/)[1];
                             // Clean up features by removing extra quotes and trimming
                             features = row.slice(1).filter(function(f) { return f && f.trim() !== ''; }).map(function(f) {
+                                // Ensure f is a string first (Papa Parse may convert numbers)
+                                var str = String(f);
                                 // Remove surrounding quotes if present
-                                var cleaned = f.trim();
+                                var cleaned = str.trim();
                                 if (cleaned.startsWith('"') && cleaned.endsWith('"')) {
                                     cleaned = cleaned.slice(1, -1);
                                 }
@@ -1725,18 +1727,22 @@ jQuery(document).ready(function($) {
         if (model === 'TERRAIN') {
             console.log('TERRAIN model detected, using GMC descriptions');
             console.log('Feature to lookup:', feature);
-            console.log('Feature uppercase:', feature.toUpperCase());
+            
+            // Convert feature to string to avoid toUpperCase errors
+            var featureString = String(feature || '');
+            console.log('Feature as string:', featureString);
+            console.log('Feature uppercase:', featureString.toUpperCase());
             console.log('Available terrain descriptions:', Object.keys(terrainFeatureDescriptions));
             
             // Try exact match first
-            description = terrainFeatureDescriptions[feature.toUpperCase()];
+            description = terrainFeatureDescriptions[featureString.toUpperCase()];
             
             // If no exact match, try partial matching
             if (!description) {
                 console.log('No exact match found, trying partial matching...');
                 var matchedKey = Object.keys(terrainFeatureDescriptions).find(function(key) {
                     // Check if the key contains the feature or vice versa
-                    return key.includes(feature.toUpperCase()) || feature.toUpperCase().includes(key);
+                    return key.includes(featureString.toUpperCase()) || featureString.toUpperCase().includes(key);
                 });
                 if (matchedKey) {
                     description = terrainFeatureDescriptions[matchedKey];
@@ -1746,7 +1752,7 @@ jQuery(document).ready(function($) {
             
             // If still no match, provide fallback
             if (!description) {
-                description = 'No GMC Terrain description available for ' + feature;
+                description = 'No GMC Terrain description available for ' + featureString;
                 console.log('No match found, using fallback description');
             }
             

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -810,7 +810,7 @@ jQuery(document).ready(function($) {
     // Load GMC Terrain feature descriptions from CSV
     var terrainFeatureDescriptions = {};
     function loadTerrainFeatureDescriptions() {
-        var csvUrl = 'https://hutchinsonautoteam.com/gmcmodels/gmcterrainfeaturedescriptions.CSV';
+        var csvUrl = 'http://hutchinsonautoteam.com/gmcmodels/gmcterraindescriptions.csv';
         console.log('Loading GMC Terrain descriptions from:', csvUrl);
         fetchCsvWithRetry(csvUrl, 'GMC Terrain Feature Descriptions', 3, 1000).then(function(csvText) {
             console.log('GMC Terrain descriptions CSV fetched successfully, length:', csvText.length);

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -635,6 +635,7 @@ jQuery(document).ready(function($) {
     var featureDescriptions = {};
     var trimLevelsData = {};
     var terrainPopulated = false;
+    var acadiaPopulated = false;
 
     // Model to field ID, CSV URL, and model filter mappings
     var modelConfigs = {
@@ -1737,176 +1738,7 @@ function populateTerrainFeaturesAfterDescriptions() {
 		trimLevelsData[model] = matchingTrimLevels;
 	}
 
-	function updateTrimLevels(model) {
-    var config = modelConfigs[model];
-    if (!config) {
-        console.warn('Model configuration not found for: ' + model);
-        return;
-    }
-    var checkboxField, htmlBlock, trimLevelsButtonBlock;
-    
-    if (model === 'TERRAIN') {
-        // For TERRAIN, checkboxes are in field 137 (HTML block)
-        checkboxField = $('#field_' + formId + '_' + terrainHtmlBlockFieldId);
-        if (!checkboxField.length) {
-            checkboxField = $('#field_' + formId + '_137');
-        }
-        if (!checkboxField.length) {
-            checkboxField = $('[id*="137"]').filter(function() {
-                return $(this).attr('id').includes('field') || $(this).attr('id').includes('input');
-            });
-        }
-        
-        console.log('TERRAIN checkboxField debug:', {
-            terrainHtmlBlockFieldId: terrainHtmlBlockFieldId,
-            selector1: '#field_' + formId + '_' + terrainHtmlBlockFieldId,
-            selector2: '#field_' + formId + '_137',
-            found: checkboxField.length,
-            actualId: checkboxField.attr('id'),
-            hasCheckboxes: checkboxField.find('input[type="checkbox"]').length
-        });
-        
-        htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
-        trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
-    } else if (model === 'ACADIA') {
-        // For ACADIA, checkboxes are in field 138 (HTML block)
-        checkboxField = $('#field_' + formId + '_' + acadiaHtmlBlockFieldId);
-        if (!checkboxField.length) {
-            checkboxField = $('#field_' + formId + '_138');
-        }
-        if (!checkboxField.length) {
-            checkboxField = $('[id*="138"]').filter(function() {
-                return $(this).attr('id').includes('field') || $(this).attr('id').includes('input');
-            });
-        }
-        
-        console.log('ACADIA checkboxField debug:', {
-            acadiaHtmlBlockFieldId: acadiaHtmlBlockFieldId,
-            selector1: '#field_' + formId + '_' + acadiaHtmlBlockFieldId,
-            selector2: '#field_' + formId + '_138',
-            found: checkboxField.length,
-            actualId: checkboxField.attr('id'),
-            hasCheckboxes: checkboxField.find('input[type="checkbox"]').length
-        });
-        
-        htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
-        trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
-    } else {
-        // For other models, checkboxes are in their respective fields
-        checkboxField = $('#field_' + formId + '_' + config.fieldId);
-        htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
-        trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
-    }
-    
-    var defaultText = 'Wonderful, it sounds like the {TRIM LEVELS} would be the best fit, which has all of these features and it is available! One moment while I plug this car in.';
-    var defaultButtonText = '<button id="viewTrimLevelsButton">View Trim Levels</button>';
-    var noMatchText = 'No matching trim levels found. Please adjust your feature selections or contact support.';
-
-    console.log('Checking ' + model + ' checkbox field (ID: ' + (model === 'TERRAIN' ? terrainHtmlBlockFieldId : model === 'ACADIA' ? acadiaHtmlBlockFieldId : config.fieldId) + '):', {
-        fieldExists: checkboxField.length > 0,
-        fieldVisible: checkboxField.is(':visible'),
-        fieldClasses: checkboxField.attr('class'),
-        fieldStyle: checkboxField.attr('style'),
-        checkboxCount: checkboxField.find('input[type="checkbox"]').length,
-        domStructure: checkboxField.html().substring(0, 500)
-    });
-
-    // Ensure feature info icons are prepended before feature labels
-    if (model === 'TERRAIN') {
-        // For TERRAIN, handle the different structure
-        checkboxField.find('.gchoice').each(function() {
-            var $div = $(this);
-            var $input = $div.find('input[type="checkbox"]');
-            var $label = $div.find('label');
-            var feature = $input.attr('value') || '';
-            
-            if (!feature || !$input.length) {
-                console.warn('Invalid TERRAIN checkbox structure in field (ID: ' + terrainHtmlBlockFieldId + ')', {
-                    feature: feature,
-                    inputExists: $input.length > 0,
-                    labelExists: $label.length > 0,
-                    divHtml: $div.html(),
-                    inputId: $input.attr('id'),
-                    labelClasses: $label.attr('class'),
-                    parentClasses: $div.attr('class')
-                });
-                return;
-            }
-            
-            var matchedFeature = Object.keys(featureDescriptions).find(function(key) {
-                return fuzzyMatch(key, feature, model, feature);
-            });
-            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
-                $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
-                console.log('Prepended info icon before TERRAIN feature: ' + feature + ', matched: ' + matchedFeature);
-            }
-        });
-    } else if (model === 'ACADIA') {
-        // For ACADIA, handle the different structure
-        checkboxField.find('.gchoice').each(function() {
-            var $div = $(this);
-            var $input = $div.find('input[type="checkbox"]');
-            var $label = $div.find('label');
-            var feature = $input.attr('value') || '';
-            
-            if (!feature || !$input.length) {
-                console.warn('Invalid ACADIA checkbox structure in field (ID: ' + acadiaHtmlBlockFieldId + ')', {
-                    feature: feature,
-                    inputExists: $input.length > 0,
-                    labelExists: $label.length > 0,
-                    divHtml: $div.html(),
-                    inputId: $input.attr('id'),
-                    labelClasses: $label.attr('class'),
-                    parentClasses: $div.attr('class')
-                });
-                return;
-            }
-            
-            var matchedFeature = Object.keys(featureDescriptions).find(function(key) {
-                return fuzzyMatch(key, feature, model, feature);
-            });
-            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
-                $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
-                console.log('Prepended info icon before ACADIA feature: ' + feature + ', matched: ' + matchedFeature);
-            }
-        });
-    } else {
-        // For other models, use existing logic
-        checkboxField.find('.gfield_checkbox > div, .gfield-choice-wrapper').each(function() {
-            var $div = $(this);
-            var $input = $div.find('input[type="checkbox"]');
-            var $label = $div.find('label, .gfield-choice-label');
-            var feature = '';
-            if ($label.length) {
-                feature = $label.contents().filter(function() {
-                    return this.nodeType === 3; // Text nodes only, excludes .feature-info-icon
-                }).text().trim();
-            }
-            if (!feature || !$input.length) {
-                console.warn('Invalid checkbox structure in field (ID: ' + config.fieldId + ')', {
-                    feature: feature,
-                    inputExists: $input.length > 0,
-                    labelExists: $label.length > 0,
-                    divHtml: $div.html(),
-                    inputId: $input.attr('id'),
-                    labelClasses: $label.attr('class'),
-                    parentClasses: $div.attr('class'),
-                    parentHtml: $div.parent().html().substring(0, 500)
-                });
-                return;
-            }
-            var matchedFeature = Object.keys(featureDescriptions).find(function(key) {
-                return model === 'K4' ? key.toUpperCase() === feature.toUpperCase() : fuzzyMatch(key, feature, model, feature);
-            });
-            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
-                $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
-                console.log('Prepended info icon before feature: ' + feature + ', matched: ' + matchedFeature);
-            }
-        });
-    }
-
     // Populate GMC Acadia features
-    var acadiaPopulated = false;
     function populateAcadiaFeatures() {
         console.log('=== populateAcadiaFeatures called ===');
         console.log('Current acadiaPopulated flag:', acadiaPopulated);
@@ -2135,6 +1967,174 @@ function populateTerrainFeaturesAfterDescriptions() {
             },
             error: function(error) {
                 console.error('❌ Error parsing Acadia CSV:', error);
+            }
+        });
+    }
+
+	function updateTrimLevels(model) {
+    var config = modelConfigs[model];
+    if (!config) {
+        console.warn('Model configuration not found for: ' + model);
+        return;
+    }
+    var checkboxField, htmlBlock, trimLevelsButtonBlock;
+    
+    if (model === 'TERRAIN') {
+        // For TERRAIN, checkboxes are in field 137 (HTML block)
+        checkboxField = $('#field_' + formId + '_' + terrainHtmlBlockFieldId);
+        if (!checkboxField.length) {
+            checkboxField = $('#field_' + formId + '_137');
+        }
+        if (!checkboxField.length) {
+            checkboxField = $('[id*="137"]').filter(function() {
+                return $(this).attr('id').includes('field') || $(this).attr('id').includes('input');
+            });
+        }
+        
+        console.log('TERRAIN checkboxField debug:', {
+            terrainHtmlBlockFieldId: terrainHtmlBlockFieldId,
+            selector1: '#field_' + formId + '_' + terrainHtmlBlockFieldId,
+            selector2: '#field_' + formId + '_137',
+            found: checkboxField.length,
+            actualId: checkboxField.attr('id'),
+            hasCheckboxes: checkboxField.find('input[type="checkbox"]').length
+        });
+        
+        htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
+        trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
+    } else if (model === 'ACADIA') {
+        // For ACADIA, checkboxes are in field 138 (HTML block)
+        checkboxField = $('#field_' + formId + '_' + acadiaHtmlBlockFieldId);
+        if (!checkboxField.length) {
+            checkboxField = $('#field_' + formId + '_138');
+        }
+        if (!checkboxField.length) {
+            checkboxField = $('[id*="138"]').filter(function() {
+                return $(this).attr('id').includes('field') || $(this).attr('id').includes('input');
+            });
+        }
+        
+        console.log('ACADIA checkboxField debug:', {
+            acadiaHtmlBlockFieldId: acadiaHtmlBlockFieldId,
+            selector1: '#field_' + formId + '_' + acadiaHtmlBlockFieldId,
+            selector2: '#field_' + formId + '_138',
+            found: checkboxField.length,
+            actualId: checkboxField.attr('id'),
+            hasCheckboxes: checkboxField.find('input[type="checkbox"]').length
+        });
+        
+        htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
+        trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
+    } else {
+        // For other models, checkboxes are in their respective fields
+        checkboxField = $('#field_' + formId + '_' + config.fieldId);
+        htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
+        trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
+    }
+    
+    var defaultText = 'Wonderful, it sounds like the {TRIM LEVELS} would be the best fit, which has all of these features and it is available! One moment while I plug this car in.';
+    var defaultButtonText = '<button id="viewTrimLevelsButton">View Trim Levels</button>';
+    var noMatchText = 'No matching trim levels found. Please adjust your feature selections or contact support.';
+
+    console.log('Checking ' + model + ' checkbox field (ID: ' + (model === 'TERRAIN' ? terrainHtmlBlockFieldId : model === 'ACADIA' ? acadiaHtmlBlockFieldId : config.fieldId) + '):', {
+        fieldExists: checkboxField.length > 0,
+        fieldVisible: checkboxField.is(':visible'),
+        fieldClasses: checkboxField.attr('class'),
+        fieldStyle: checkboxField.attr('style'),
+        checkboxCount: checkboxField.find('input[type="checkbox"]').length,
+        domStructure: checkboxField.html().substring(0, 500)
+    });
+
+    // Ensure feature info icons are prepended before feature labels
+    if (model === 'TERRAIN') {
+        // For TERRAIN, handle the different structure
+        checkboxField.find('.gchoice').each(function() {
+            var $div = $(this);
+            var $input = $div.find('input[type="checkbox"]');
+            var $label = $div.find('label');
+            var feature = $input.attr('value') || '';
+            
+            if (!feature || !$input.length) {
+                console.warn('Invalid TERRAIN checkbox structure in field (ID: ' + terrainHtmlBlockFieldId + ')', {
+                    feature: feature,
+                    inputExists: $input.length > 0,
+                    labelExists: $label.length > 0,
+                    divHtml: $div.html(),
+                    inputId: $input.attr('id'),
+                    labelClasses: $label.attr('class'),
+                    parentClasses: $div.attr('class')
+                });
+                return;
+            }
+            
+            var matchedFeature = Object.keys(featureDescriptions).find(function(key) {
+                return fuzzyMatch(key, feature, model, feature);
+            });
+            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
+                $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
+                console.log('Prepended info icon before TERRAIN feature: ' + feature + ', matched: ' + matchedFeature);
+            }
+        });
+    } else if (model === 'ACADIA') {
+        // For ACADIA, handle the different structure
+        checkboxField.find('.gchoice').each(function() {
+            var $div = $(this);
+            var $input = $div.find('input[type="checkbox"]');
+            var $label = $div.find('label');
+            var feature = $input.attr('value') || '';
+            
+            if (!feature || !$input.length) {
+                console.warn('Invalid ACADIA checkbox structure in field (ID: ' + acadiaHtmlBlockFieldId + ')', {
+                    feature: feature,
+                    inputExists: $input.length > 0,
+                    labelExists: $label.length > 0,
+                    divHtml: $div.html(),
+                    inputId: $input.attr('id'),
+                    labelClasses: $label.attr('class'),
+                    parentClasses: $div.attr('class')
+                });
+                return;
+            }
+            
+            var matchedFeature = Object.keys(featureDescriptions).find(function(key) {
+                return fuzzyMatch(key, feature, model, feature);
+            });
+            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
+                $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
+                console.log('Prepended info icon before ACADIA feature: ' + feature + ', matched: ' + matchedFeature);
+            }
+        });
+    } else {
+        // For other models, use existing logic
+        checkboxField.find('.gfield_checkbox > div, .gfield-choice-wrapper').each(function() {
+            var $div = $(this);
+            var $input = $div.find('input[type="checkbox"]');
+            var $label = $div.find('label, .gfield-choice-label');
+            var feature = '';
+            if ($label.length) {
+                feature = $label.contents().filter(function() {
+                    return this.nodeType === 3; // Text nodes only, excludes .feature-info-icon
+                }).text().trim();
+            }
+            if (!feature || !$input.length) {
+                console.warn('Invalid checkbox structure in field (ID: ' + config.fieldId + ')', {
+                    feature: feature,
+                    inputExists: $input.length > 0,
+                    labelExists: $label.length > 0,
+                    divHtml: $div.html(),
+                    inputId: $input.attr('id'),
+                    labelClasses: $label.attr('class'),
+                    parentClasses: $div.attr('class'),
+                    parentHtml: $div.parent().html().substring(0, 500)
+                });
+                return;
+            }
+            var matchedFeature = Object.keys(featureDescriptions).find(function(key) {
+                return model === 'K4' ? key.toUpperCase() === feature.toUpperCase() : fuzzyMatch(key, feature, model, feature);
+            });
+            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
+                $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
+                console.log('Prepended info icon before feature: ' + feature + ', matched: ' + matchedFeature);
             }
         });
     }

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -812,7 +812,7 @@ jQuery(document).ready(function($) {
     function loadTerrainFeatureDescriptions() {
         var csvUrl = 'https://hutchinsonautoteam.com/gmcmodels/gmcterraindescriptions.csv';
         console.log('Loading GMC Terrain descriptions from:', csvUrl);
-        fetchCsvWithRetry(csvUrl, 'GMC Terrain Feature Descriptions', 3, 1000).then(function(csvText) {
+        return fetchCsvWithRetry(csvUrl, 'GMC Terrain Feature Descriptions', 3, 1000).then(function(csvText) {
             console.log('GMC Terrain descriptions CSV fetched successfully, length:', csvText.length);
             console.log('First 500 characters of CSV:', csvText.substring(0, 500));
             
@@ -888,9 +888,11 @@ jQuery(document).ready(function($) {
             } else {
                 console.log('✅ SUCCESS: GMC Terrain descriptions loaded successfully!');
             }
+            return terrainFeatureDescriptions;
         }).catch(function(error) {
             console.error('❌ Fetch error for GMC Terrain Feature Descriptions:', error.message);
             terrainFeatureDescriptions = {};
+            throw error;
         });
     }
 
@@ -1027,6 +1029,27 @@ jQuery(document).ready(function($) {
         return;
     }
 
+    // Load terrain descriptions first if not already loaded
+    if (!terrainFeatureDescriptions || Object.keys(terrainFeatureDescriptions).length === 0) {
+        console.log('🚨 Terrain descriptions not loaded, loading first...');
+        // Load descriptions and then populate features
+        loadTerrainFeatureDescriptions().then(function() {
+            console.log('✅ Descriptions loaded, now populating features...');
+            populateTerrainFeaturesAfterDescriptions();
+        }).catch(function(error) {
+            console.error('❌ Failed to load descriptions:', error);
+            // Continue anyway with basic feature names
+            populateTerrainFeaturesAfterDescriptions();
+        });
+        return;
+    }
+    
+    populateTerrainFeaturesAfterDescriptions();
+}
+
+function populateTerrainFeaturesAfterDescriptions() {
+    console.log('=== populateTerrainFeaturesAfterDescriptions called ===');
+
     var config = modelConfigs['TERRAIN'];
     if (!config) {
         console.warn('Terrain configuration not found');
@@ -1162,12 +1185,23 @@ jQuery(document).ready(function($) {
                         }
                         window.terrainFeatureMap[simpleValue] = feature;
                         
+                        // Try to find the full feature name from terrain descriptions
+                        var fullFeatureName = feature;
+                        if (terrainFeatureDescriptions && Object.keys(terrainFeatureDescriptions).length > 0) {
+                            var matchedKey = Object.keys(terrainFeatureDescriptions).find(function(key) {
+                                return key.includes(String(feature).toUpperCase()) || String(feature).toUpperCase().includes(key);
+                            });
+                            if (matchedKey) {
+                                fullFeatureName = matchedKey;
+                            }
+                        }
+                        
                         // Build HTML using simple string concatenation to avoid any quote issues
                         var divStart = '<div class="gchoice gchoice_terrain_' + globalIndex + '">';
                         var inputTag = '<input name="' + inputName + '" type="checkbox" value="' + simpleValue + '" data-category="' + category + '" id="' + uniqueId + '">';
-                        var labelTag = '<label for="' + uniqueId + '" id="label_terrain_' + globalIndex + '">' + feature + '</label>';
-                        // Add feature info icon for terrain features
-                        var infoIcon = '<span class="feature-info-icon terrain-info-icon" data-feature="' + String(feature) + '" style="margin-left: 8px; cursor: pointer; color: #007cba; font-weight: bold; font-size: 16px; border: 1px solid #007cba; border-radius: 50%; width: 20px; height: 20px; display: inline-block; text-align: center; line-height: 18px; background-color: #f0f8ff;" title="Click for GMC Terrain feature description">ℹ</span>';
+                        var labelTag = '<label for="' + uniqueId + '" id="label_terrain_' + globalIndex + '">' + fullFeatureName + '</label>';
+                        // Add feature info icon for terrain features - use full feature name for data-feature
+                        var infoIcon = '<span class="feature-info-icon terrain-info-icon" data-feature="' + String(fullFeatureName) + '" style="margin-left: 8px; cursor: pointer; color: #007cba; font-weight: bold; font-size: 16px; border: 1px solid #007cba; border-radius: 50%; width: 20px; height: 20px; display: inline-block; text-align: center; line-height: 18px; background-color: #f0f8ff;" title="Click for GMC Terrain feature description">ℹ</span>';
                         var divEnd = '</div>';
                         
                         html += divStart + inputTag + labelTag + infoIcon + divEnd;

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -1432,19 +1432,51 @@ function populateTerrainFeaturesAfterDescriptions() {
                     
                     console.log('Looking for feature (uppercase):', feature.toUpperCase());
                     
-                    // Try exact match first
-                    var description = terrainFeatureDescriptions[feature.toUpperCase()];
+                    // Normalize feature name to handle common typos
+                    function normalizeFeatureName(featureName) {
+                        return featureName
+                            .replace(/INFOTAINTMENT/g, 'INFOTAINMENT')  // Fix common typo
+                            .replace(/\s+/g, ' ')                       // Normalize whitespace
+                            .trim();
+                    }
                     
-                    // If no exact match, try partial matching
+                    var normalizedFeature = normalizeFeatureName(feature.toUpperCase());
+                    console.log('Normalized feature:', normalizedFeature);
+                    
+                    // Try exact match first with normalized feature
+                    var description = terrainFeatureDescriptions[normalizedFeature];
+                    if (description) {
+                        console.log('✅ Found exact match with normalized feature:', normalizedFeature);
+                    }
+                    
+                    // If no exact match, try with original feature name
+                    if (!description) {
+                        description = terrainFeatureDescriptions[feature.toUpperCase()];
+                        if (description) {
+                            console.log('✅ Found exact match with original feature:', feature.toUpperCase());
+                        }
+                    }
+                    
+                    // If still no match, try partial matching with normalized names
                     if (!description) {
                         console.log('No exact match found, trying partial matching...');
+                        console.log('Searching for normalized feature:', normalizedFeature);
                         var matchedKey = Object.keys(terrainFeatureDescriptions).find(function(key) {
-                            // Check if the key contains the feature or vice versa
-                            return key.includes(feature.toUpperCase()) || feature.toUpperCase().includes(key);
+                            var normalizedKey = normalizeFeatureName(key);
+                            var keyContainsFeature = normalizedKey.includes(normalizedFeature);
+                            var featureContainsKey = normalizedFeature.includes(normalizedKey);
+                            
+                            if (keyContainsFeature || featureContainsKey) {
+                                console.log('Partial match candidate:', key, '(normalized:', normalizedKey, ')');
+                                return true;
+                            }
+                            return false;
                         });
                         if (matchedKey) {
                             description = terrainFeatureDescriptions[matchedKey];
-                            console.log('Found partial match:', matchedKey);
+                            console.log('✅ Found partial match:', matchedKey);
+                        } else {
+                            console.log('❌ No partial match found');
                         }
                     }
                     
@@ -1948,19 +1980,51 @@ function populateTerrainFeaturesAfterDescriptions() {
                         
                         console.log('Looking for feature (uppercase):', feature.toUpperCase());
                         
-                        // Try exact match first
-                        var description = acadiaFeatureDescriptions[feature.toUpperCase()];
+                        // Normalize feature name to handle common typos
+                        function normalizeFeatureName(featureName) {
+                            return featureName
+                                .replace(/INFOTAINTMENT/g, 'INFOTAINMENT')  // Fix common typo
+                                .replace(/\s+/g, ' ')                       // Normalize whitespace
+                                .trim();
+                        }
                         
-                        // If no exact match, try partial matching
+                        var normalizedFeature = normalizeFeatureName(feature.toUpperCase());
+                        console.log('Normalized feature:', normalizedFeature);
+                        
+                        // Try exact match first with normalized feature
+                        var description = acadiaFeatureDescriptions[normalizedFeature];
+                        if (description) {
+                            console.log('✅ Found exact match with normalized feature:', normalizedFeature);
+                        }
+                        
+                        // If no exact match, try with original feature name
+                        if (!description) {
+                            description = acadiaFeatureDescriptions[feature.toUpperCase()];
+                            if (description) {
+                                console.log('✅ Found exact match with original feature:', feature.toUpperCase());
+                            }
+                        }
+                        
+                        // If still no match, try partial matching with normalized names
                         if (!description) {
                             console.log('No exact match found, trying partial matching...');
+                            console.log('Searching for normalized feature:', normalizedFeature);
                             var matchedKey = Object.keys(acadiaFeatureDescriptions).find(function(key) {
-                                // Check if the key contains the feature or vice versa
-                                return key.includes(feature.toUpperCase()) || feature.toUpperCase().includes(key);
+                                var normalizedKey = normalizeFeatureName(key);
+                                var keyContainsFeature = normalizedKey.includes(normalizedFeature);
+                                var featureContainsKey = normalizedFeature.includes(normalizedKey);
+                                
+                                if (keyContainsFeature || featureContainsKey) {
+                                    console.log('Partial match candidate:', key, '(normalized:', normalizedKey, ')');
+                                    return true;
+                                }
+                                return false;
                             });
                             if (matchedKey) {
                                 description = acadiaFeatureDescriptions[matchedKey];
-                                console.log('Found partial match:', matchedKey);
+                                console.log('✅ Found partial match:', matchedKey);
+                            } else {
+                                console.log('❌ No partial match found');
                             }
                         }
                         

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -1167,7 +1167,7 @@ jQuery(document).ready(function($) {
                         var inputTag = '<input name="' + inputName + '" type="checkbox" value="' + simpleValue + '" data-category="' + category + '" id="' + uniqueId + '">';
                         var labelTag = '<label for="' + uniqueId + '" id="label_terrain_' + globalIndex + '">' + feature + '</label>';
                         // Add feature info icon for terrain features
-                        var infoIcon = '<span class="feature-info-icon terrain-info-icon" data-feature="' + feature + '" style="margin-left: 8px; cursor: pointer; color: #007cba; font-weight: bold; font-size: 16px; border: 1px solid #007cba; border-radius: 50%; width: 20px; height: 20px; display: inline-block; text-align: center; line-height: 18px; background-color: #f0f8ff;" title="Click for GMC Terrain feature description">ℹ</span>';
+                        var infoIcon = '<span class="feature-info-icon terrain-info-icon" data-feature="' + String(feature) + '" style="margin-left: 8px; cursor: pointer; color: #007cba; font-weight: bold; font-size: 16px; border: 1px solid #007cba; border-radius: 50%; width: 20px; height: 20px; display: inline-block; text-align: center; line-height: 18px; background-color: #f0f8ff;" title="Click for GMC Terrain feature description">ℹ</span>';
                         var divEnd = '</div>';
                         
                         html += divStart + inputTag + labelTag + infoIcon + divEnd;
@@ -1262,8 +1262,8 @@ jQuery(document).ready(function($) {
                         var matchedFeature = Object.keys(featureDescriptions).find(function(key) {
                             return fuzzyMatch(key, feature, 'TERRAIN', feature);
                         });
-                        if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + matchedFeature + '"]').length) {
-                            $label.prepend('<span class="feature-info-icon" data-feature="' + matchedFeature + '">i</span>');
+                        if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
+                            $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
                             console.log('Prepended info icon for feature: ' + feature);
                         }
                     }
@@ -1677,8 +1677,8 @@ jQuery(document).ready(function($) {
             var matchedFeature = Object.keys(featureDescriptions).find(function(key) {
                 return fuzzyMatch(key, feature, model, feature);
             });
-            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + matchedFeature + '"]').length) {
-                $label.prepend('<span class="feature-info-icon" data-feature="' + matchedFeature + '">i</span>');
+            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
+                $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
                 console.log('Prepended info icon before TERRAIN feature: ' + feature + ', matched: ' + matchedFeature);
             }
         });
@@ -1710,8 +1710,8 @@ jQuery(document).ready(function($) {
             var matchedFeature = Object.keys(featureDescriptions).find(function(key) {
                 return model === 'K4' ? key.toUpperCase() === feature.toUpperCase() : fuzzyMatch(key, feature, model, feature);
             });
-            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + matchedFeature + '"]').length) {
-                $label.prepend('<span class="feature-info-icon" data-feature="' + matchedFeature + '">i</span>');
+            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
+                $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
                 console.log('Prepended info icon before feature: ' + feature + ', matched: ' + matchedFeature);
             }
         });

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -810,7 +810,7 @@ jQuery(document).ready(function($) {
     // Load GMC Terrain feature descriptions from CSV
     var terrainFeatureDescriptions = {};
     function loadTerrainFeatureDescriptions() {
-        var csvUrl = 'http://hutchinsonautoteam.com/gmcmodels/gmcterraindescriptions.csv';
+        var csvUrl = 'https://hutchinsonautoteam.com/gmcmodels/gmcterraindescriptions.csv';
         console.log('Loading GMC Terrain descriptions from:', csvUrl);
         fetchCsvWithRetry(csvUrl, 'GMC Terrain Feature Descriptions', 3, 1000).then(function(csvText) {
             console.log('GMC Terrain descriptions CSV fetched successfully, length:', csvText.length);

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -1272,7 +1272,7 @@ jQuery(document).ready(function($) {
                 htmlBlock.find('.feature-info-icon').off('click.featureInfo').on('click.featureInfo', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    var feature = $(this).data('feature');
+                    var feature = $(this).attr('data-feature');
                     console.log('=== TERRAIN FEATURE INFO ICON CLICKED ===');
                     console.log('Feature clicked:', feature);
                     console.log('Feature type:', typeof feature);
@@ -1721,7 +1721,7 @@ jQuery(document).ready(function($) {
     checkboxField.find('.feature-info-icon').off('click.featureInfo').on('click.featureInfo', function(e) {
         e.preventDefault();
         e.stopPropagation();
-        var feature = $(this).data('feature');
+        var feature = $(this).attr('data-feature');
         // Use GMC Terrain descriptions for TERRAIN model, otherwise use KIA descriptions
         var description;
         if (model === 'TERRAIN') {

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -3967,18 +3967,37 @@ function initFormBindings() {
                 var overlay = $('#trimLevelsOverlay');
 
                 console.log('Trim Levels popup created for ' + model + ' (Model: ' + modelFilter + '), exists: ' + (popup.length > 0));
+                console.log('Trim Levels overlay created, exists: ' + (overlay.length > 0));
+                console.log('Popup HTML length: ' + popupHtml.length);
 
-                overlay.on('click', function(e) {
-                    if (e.target.id === 'trimLevelsOverlay') {
-                        console.log('Trim Levels overlay clicked, closing popup');
-                        $('#trimLevelsPopup, #trimLevelsOverlay').remove();
-                    }
-                });
+                // Add a small delay before binding overlay click to prevent immediate closing
+                var popupCreationTime = Date.now();
+                setTimeout(function() {
+                    overlay.on('click', function(e) {
+                        var timeSinceCreation = Date.now() - popupCreationTime;
+                        console.log('Trim Levels overlay clicked after ' + timeSinceCreation + 'ms, event target: ' + e.target.id);
+                        if (e.target.id === 'trimLevelsOverlay' && timeSinceCreation > 300) {
+                            console.log('Trim Levels overlay clicked, closing popup');
+                            $('#trimLevelsPopup, #trimLevelsOverlay').remove();
+                        } else if (timeSinceCreation <= 300) {
+                            console.log('Overlay click ignored - too soon after creation (' + timeSinceCreation + 'ms)');
+                        }
+                    });
+                }, 100);
 
                 popup.find('.trim-close-popup').on('click', function() {
                     console.log('Trim Levels close button clicked, closing popup');
                     $('#trimLevelsPopup, #trimLevelsOverlay').remove();
                 });
+
+                // Add a check to see if popup still exists after a short delay
+                setTimeout(function() {
+                    var popupStillExists = $('#trimLevelsPopup').length > 0;
+                    console.log('Popup still exists after 200ms: ' + popupStillExists);
+                    if (!popupStillExists) {
+                        console.log('⚠️ Popup was removed unexpectedly - investigating cause');
+                    }
+                }, 200);
 
                 popup.find('.copy-stock-link').on('click', function(e) {
                     e.preventDefault();

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -548,6 +548,11 @@ jQuery(document).ready(function($) {
         .gchoice[class*="gchoice_terrain_"] {\
             margin-bottom: 4% !important;\
             padding-bottom: 4px;\
+        }\
+        /* Acadia checkbox spacing */\
+        .gchoice[class*="gchoice_acadia_"] {\
+            margin-bottom: 4% !important;\
+            padding-bottom: 4px;\
         }';
     $('head').append('<style id="popupStyles">' + cssStyles + '</style>');
     console.log('Inline vehicle popup, Field 57, Generate Note, feature popup, trim levels popup, and Push to DriveCentric buttons CSS appended');
@@ -1905,12 +1910,21 @@ function populateTerrainFeaturesAfterDescriptions() {
                     acadiaPopulated = true;
                     console.log('✅ Acadia features populated successfully!');
                     
+                    // Store the CSV data for trim level matching
+                    var acadiaCsvData = results.data;
+                    
+                    // Initial trim level check (no features selected)
+                    checkAcadiaMatchingTrimLevels(acadiaCsvData);
+                    
                     // Bind change events
                     htmlBlock.find('input[type="checkbox"]').on('change', function() {
                         var featureValue = this.value;
                         var featureName = window.acadiaFeatureMap[featureValue];
                         var category = $(this).data('category');
                         console.log('ACADIA feature changed:', featureName, 'Category:', category, 'Checked:', this.checked);
+                        
+                        // Check for matching trim levels
+                        checkAcadiaMatchingTrimLevels(acadiaCsvData);
                     });
 
                     htmlBlock.find('.feature-info-icon').off('click.featureInfo').on('click.featureInfo', function(e) {
@@ -1969,6 +1983,193 @@ function populateTerrainFeaturesAfterDescriptions() {
                 console.error('❌ Error parsing Acadia CSV:', error);
             }
         });
+    }
+
+    // Check for matching Acadia trim levels
+    function checkAcadiaMatchingTrimLevels(csvData) {
+        var model = 'ACADIA';
+        var trimLevels = ['ELEVATION', 'DENALI', 'AT4'];
+        var htmlBlockFieldId = 69; // Field ID for {TRIM LEVELS} replacement
+        
+        // Get selected features
+        var selectedFeatures = [];
+        $('#field_' + formId + '_' + acadiaHtmlBlockFieldId + ' input[type="checkbox"]:checked').each(function() {
+            var featureValue = $(this).val();
+            var featureName = window.acadiaFeatureMap[featureValue];
+            if (featureName) {
+                selectedFeatures.push(featureName);
+            }
+        });
+        
+        console.log('Selected ACADIA features:', selectedFeatures);
+        
+        if (selectedFeatures.length === 0) {
+            $('#field_' + formId + '_' + htmlBlockFieldId).html('<p>Select features to see matching trim levels</p>');
+            return;
+        }
+        
+        var matchingTrimLevels = [];
+        var categories = ['EXTERIOR', 'INTERIOR', 'MECHANICAL', 'SAFETY', 'PACKAGES'];
+        var featureToColumnMap = {};
+        var featureToCategoryMap = {};
+        var trimLevelRows = {};
+        var trimLevelRowsByCategory = {};
+        var currentCategory = null;
+        
+        // Parse the CSV data to map features to columns and find trim level rows
+        csvData.forEach(function(row, rowIndex) {
+            if (row.length > 0) {
+                var firstCell = row[0] ? row[0].trim() : '';
+                
+                // Check if this is a category header row
+                if (firstCell.startsWith('TRIM LEVELS FOR {')) {
+                    var category = firstCell.match(/\{(.+)\}/)[1];
+                    currentCategory = category;
+                    console.log('Found ACADIA category:', category);
+                    
+                    // Initialize category storage if not exists
+                    if (!trimLevelRowsByCategory[category]) {
+                        trimLevelRowsByCategory[category] = {};
+                    }
+                    
+                    // Map features to their column indices
+                    for (var i = 1; i < row.length; i++) {
+                        var feature = row[i] ? row[i].trim() : '';
+                        if (feature && feature !== '') {
+                            // Clean up the feature name the same way as in populateAcadiaFeatures
+                            var cleanedFeature = feature;
+                            if (cleanedFeature.startsWith('"') && cleanedFeature.endsWith('"')) {
+                                cleanedFeature = cleanedFeature.slice(1, -1);
+                            }
+                            cleanedFeature = cleanedFeature.replace(/""/g, '"');
+                            
+                            featureToColumnMap[cleanedFeature] = i;
+                            featureToCategoryMap[cleanedFeature] = category;
+                            console.log('Mapped ACADIA feature "' + cleanedFeature + '" (raw: "' + feature + '") to column ' + i + ' in category ' + category);
+                        }
+                    }
+                }
+                // Check if this is a trim level row
+                else if (trimLevels.includes(firstCell) && currentCategory) {
+                    // Store in both global and category-specific storage
+                    trimLevelRows[firstCell] = row;
+                    trimLevelRowsByCategory[currentCategory][firstCell] = row;
+                    console.log('Found ACADIA trim level row for:', firstCell, 'in category:', currentCategory);
+                }
+            }
+        });
+        
+        console.log('ACADIA Feature to column mapping:', featureToColumnMap);
+        console.log('ACADIA Feature to category mapping:', featureToCategoryMap);
+        console.log('ACADIA Trim level rows:', Object.keys(trimLevelRows));
+        console.log('ACADIA Trim level rows by category:', trimLevelRowsByCategory);
+        
+        // Check which trim levels have all selected features
+        trimLevels.forEach(function(trimLevel) {
+            if (trimLevelRows[trimLevel]) {
+                var hasAllFeatures = true;
+                var featureResults = [];
+                
+                selectedFeatures.forEach(function(feature) {
+                    var columnIndex = featureToColumnMap[feature];
+                    var matchedFeature = feature;
+                    
+                    // If exact match not found, try fuzzy matching
+                    if (columnIndex === undefined) {
+                        console.log('ACADIA Feature "' + feature + '" not found in column mapping, trying fuzzy matching...');
+                        var bestMatch = null;
+                        var bestSimilarity = 0;
+                        
+                        Object.keys(featureToColumnMap).forEach(function(csvFeature) {
+                            var similarity = fuzzyMatch(csvFeature, feature, model, feature);
+                            if (similarity > bestSimilarity && similarity > 0.5) {
+                                bestMatch = csvFeature;
+                                bestSimilarity = similarity;
+                            }
+                        });
+                        
+                        if (bestMatch) {
+                            columnIndex = featureToColumnMap[bestMatch];
+                            matchedFeature = bestMatch;
+                            console.log('Found ACADIA fuzzy match for "' + feature + '": "' + bestMatch + '" (similarity: ' + bestSimilarity + ')');
+                        }
+                    }
+                    
+                    if (columnIndex !== undefined) {
+                        var value = '';
+                        var featureCategory = featureToCategoryMap[matchedFeature];
+                        
+                        // Try to get value from category-specific storage first
+                        if (featureCategory && trimLevelRowsByCategory[featureCategory] && trimLevelRowsByCategory[featureCategory][trimLevel]) {
+                            value = trimLevelRowsByCategory[featureCategory][trimLevel][columnIndex];
+                        } else {
+                            // Fall back to global storage
+                            value = trimLevelRows[trimLevel][columnIndex];
+                        }
+                        
+                        var hasFeature = value && (value.trim().toUpperCase() === 'YES' || value.trim().toUpperCase() === 'Y');
+                        featureResults.push({
+                            feature: feature,
+                            matchedFeature: matchedFeature,
+                            value: value,
+                            hasFeature: hasFeature,
+                            column: columnIndex,
+                            category: featureCategory
+                        });
+                        
+                        if (!hasFeature) {
+                            hasAllFeatures = false;
+                        }
+                        
+                        console.log('ACADIA Trim level ' + trimLevel + ' - Feature "' + feature + '" (matched: "' + matchedFeature + '") in column ' + columnIndex + ': "' + value + '" (has feature: ' + hasFeature + ')');
+                    } else {
+                        console.log('ACADIA Feature "' + feature + '" not found in CSV columns');
+                        hasAllFeatures = false;
+                        featureResults.push({
+                            feature: feature,
+                            matchedFeature: 'NOT FOUND',
+                            value: 'N/A',
+                            hasFeature: false,
+                            column: -1,
+                            category: 'UNKNOWN'
+                        });
+                    }
+                });
+                
+                if (hasAllFeatures) {
+                    matchingTrimLevels.push(trimLevel);
+                }
+                
+                console.log('ACADIA Trim level ' + trimLevel + ' has all features: ' + hasAllFeatures);
+                console.log('ACADIA Feature results for ' + trimLevel + ':', featureResults);
+            }
+        });
+        
+        console.log('ACADIA Matching trim levels:', matchingTrimLevels);
+        
+        // Update the HTML block with matching trim levels
+        var htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
+        if (htmlBlock.length) {
+            if (matchingTrimLevels.length > 0) {
+                var trimLevelText = matchingTrimLevels.join(', ');
+                var html = '<p>Wonderful, it sounds like the <strong>' + trimLevelText + '</strong> would be the best fit, which has all of these features and it is available! One moment while I plug this car in.</p>';
+                html += '<button id="viewAcadiaTrimLevelsButton" style="margin-top: 10px; padding: 8px 16px; background-color: #007cba; color: white; border: none; border-radius: 4px; cursor: pointer;">View Trim Levels</button>';
+                htmlBlock.html(html);
+                
+                // Bind click event for trim levels button
+                $('#viewAcadiaTrimLevelsButton').off('click').on('click', function() {
+                    console.log('ACADIA View Trim Levels button clicked');
+                    showTrimLevelsPopup(model, matchingTrimLevels, model);
+                });
+            } else {
+                htmlBlock.html('<p>No matching trim levels found. Please adjust your feature selections.</p>');
+            }
+        } else {
+            console.error('❌ HTML block not found for field ID:', htmlBlockFieldId);
+        }
+        
+        // Store the results
+        trimLevelsData[model] = matchingTrimLevels;
     }
 
 	function updateTrimLevels(model) {

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -622,6 +622,8 @@ jQuery(document).ready(function($) {
     var gmcModelFieldId = 107;
     var terrainCheckboxFieldId = 129;
     var terrainHtmlBlockFieldId = 137;
+    var acadiaCheckboxFieldId = 130;
+    var acadiaHtmlBlockFieldId = 138;
 
     // Global variables
     var vehicleData = null;
@@ -651,7 +653,8 @@ jQuery(document).ready(function($) {
         'SPORTAGE': { fieldId: sportageCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/kiamodels/SPORTAGE.csv', modelFilter: 'Sportage' },
         'SPORTAGE-HYBRID': { fieldId: sportageHybridCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/kiamodels/SPORTAGE-HYBRID.csv', modelFilter: 'Sportage Hybrid' },
         'TELLURIDE': { fieldId: tellurideCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/kiamodels/TELLURIDE.csv', modelFilter: 'Telluride' },
-        'TERRAIN': { fieldId: terrainCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/gmcmodels/terrain.csv', modelFilter: 'Terrain', isGmc: true }
+        'TERRAIN': { fieldId: terrainCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/gmcmodels/terrain.csv', modelFilter: 'Terrain', isGmc: true },
+        'ACADIA': { fieldId: acadiaCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/gmcmodels/acadia.csv', modelFilter: 'Acadia', isGmc: true }
     };
 
     // Email mappings
@@ -892,6 +895,94 @@ jQuery(document).ready(function($) {
         }).catch(function(error) {
             console.error('❌ Fetch error for GMC Terrain Feature Descriptions:', error.message);
             terrainFeatureDescriptions = {};
+            throw error;
+        });
+    }
+
+    // Load GMC Acadia feature descriptions from CSV
+    var acadiaFeatureDescriptions = {};
+    function loadAcadiaFeatureDescriptions() {
+        var csvUrl = 'https://hutchinsonautoteam.com/gmcmodels/gmcacadiadescriptions.csv';
+        console.log('Loading GMC Acadia descriptions from:', csvUrl);
+        return fetchCsvWithRetry(csvUrl, 'GMC Acadia Feature Descriptions', 3, 1000).then(function(csvText) {
+            console.log('GMC Acadia descriptions CSV fetched successfully, length:', csvText.length);
+            console.log('First 500 characters of CSV:', csvText.substring(0, 500));
+            
+            // Parse the new CSV format with curly braces: {FEATURE_NAME :Description}
+            acadiaFeatureDescriptions = {};
+            
+            // Find all entries enclosed in curly braces - more robust regex
+            var curlyBraceRegex = /\{([^}]+)\}/g;
+            var matches = [];
+            var match;
+            
+            // Use exec to get all matches with better error handling
+            while ((match = curlyBraceRegex.exec(csvText)) !== null) {
+                matches.push(match[0]);
+            }
+            
+            console.log('📊 Found', matches.length, 'GMC Acadia description entries');
+            
+            if (matches.length > 0) {
+                matches.forEach(function(matchText, index) {
+                    try {
+                        // Remove outer curly braces
+                        var content = matchText.slice(1, -1);
+                        
+                        // Look for ' :' (space + colon) separator
+                        var colonIndex = content.indexOf(' :');
+                        
+                        if (colonIndex !== -1) {
+                            var feature = content.substring(0, colonIndex).trim();
+                            var description = content.substring(colonIndex + 2).trim(); // +2 to skip ' :'
+                            
+                            if (feature && description) {
+                                // Store with case-insensitive key for matching
+                                acadiaFeatureDescriptions[feature.toUpperCase()] = description;
+                                console.log('✅ Loaded GMC Acadia description for:', feature);
+                            } else {
+                                console.warn('❌ Empty feature or description:', { 
+                                    feature: feature, 
+                                    description: description.substring(0, 50) + '...',
+                                    hasFeature: !!feature,
+                                    hasDescription: !!description
+                                });
+                            }
+                        } else {
+                            console.warn('❌ Could not find " :" separator in:', content.substring(0, 100));
+                            
+                            // Try fallback with just ':' separator
+                            var altColonIndex = content.indexOf(':');
+                            if (altColonIndex !== -1) {
+                                var altFeature = content.substring(0, altColonIndex).trim();
+                                var altDescription = content.substring(altColonIndex + 1).trim();
+                                if (altFeature && altDescription) {
+                                    acadiaFeatureDescriptions[altFeature.toUpperCase()] = altDescription;
+                                    console.log('✅ Loaded GMC Acadia description (alt format) for:', altFeature);
+                                }
+                            }
+                        }
+                    } catch (error) {
+                        console.error('❌ Error parsing acadia description entry:', error, matchText.substring(0, 100));
+                    }
+                });
+            } else {
+                console.warn('❌ No curly brace entries found in CSV');
+                console.log('CSV content preview:', csvText.substring(0, 1000));
+            }
+            
+            console.log('GMC Acadia Feature Descriptions loaded, features:', Object.keys(acadiaFeatureDescriptions).length);
+            console.log('Sample features loaded:', Object.keys(acadiaFeatureDescriptions).slice(0, 5));
+            console.log('All acadia features loaded:', Object.keys(acadiaFeatureDescriptions));
+            if (Object.keys(acadiaFeatureDescriptions).length === 0) {
+                console.warn('❌ No GMC Acadia descriptions were parsed from CSV');
+            } else {
+                console.log('✅ SUCCESS: GMC Acadia descriptions loaded successfully!');
+            }
+            return acadiaFeatureDescriptions;
+        }).catch(function(error) {
+            console.error('❌ Fetch error for GMC Acadia Feature Descriptions:', error.message);
+            acadiaFeatureDescriptions = {};
             throw error;
         });
     }
@@ -1677,6 +1768,29 @@ function populateTerrainFeaturesAfterDescriptions() {
         
         htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
         trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
+    } else if (model === 'ACADIA') {
+        // For ACADIA, checkboxes are in field 138 (HTML block)
+        checkboxField = $('#field_' + formId + '_' + acadiaHtmlBlockFieldId);
+        if (!checkboxField.length) {
+            checkboxField = $('#field_' + formId + '_138');
+        }
+        if (!checkboxField.length) {
+            checkboxField = $('[id*="138"]').filter(function() {
+                return $(this).attr('id').includes('field') || $(this).attr('id').includes('input');
+            });
+        }
+        
+        console.log('ACADIA checkboxField debug:', {
+            acadiaHtmlBlockFieldId: acadiaHtmlBlockFieldId,
+            selector1: '#field_' + formId + '_' + acadiaHtmlBlockFieldId,
+            selector2: '#field_' + formId + '_138',
+            found: checkboxField.length,
+            actualId: checkboxField.attr('id'),
+            hasCheckboxes: checkboxField.find('input[type="checkbox"]').length
+        });
+        
+        htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
+        trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
     } else {
         // For other models, checkboxes are in their respective fields
         checkboxField = $('#field_' + formId + '_' + config.fieldId);
@@ -1688,7 +1802,7 @@ function populateTerrainFeaturesAfterDescriptions() {
     var defaultButtonText = '<button id="viewTrimLevelsButton">View Trim Levels</button>';
     var noMatchText = 'No matching trim levels found. Please adjust your feature selections or contact support.';
 
-    console.log('Checking ' + model + ' checkbox field (ID: ' + (model === 'TERRAIN' ? terrainHtmlBlockFieldId : config.fieldId) + '):', {
+    console.log('Checking ' + model + ' checkbox field (ID: ' + (model === 'TERRAIN' ? terrainHtmlBlockFieldId : model === 'ACADIA' ? acadiaHtmlBlockFieldId : config.fieldId) + '):', {
         fieldExists: checkboxField.length > 0,
         fieldVisible: checkboxField.is(':visible'),
         fieldClasses: checkboxField.attr('class'),
@@ -1727,6 +1841,35 @@ function populateTerrainFeaturesAfterDescriptions() {
                 console.log('Prepended info icon before TERRAIN feature: ' + feature + ', matched: ' + matchedFeature);
             }
         });
+    } else if (model === 'ACADIA') {
+        // For ACADIA, handle the different structure
+        checkboxField.find('.gchoice').each(function() {
+            var $div = $(this);
+            var $input = $div.find('input[type="checkbox"]');
+            var $label = $div.find('label');
+            var feature = $input.attr('value') || '';
+            
+            if (!feature || !$input.length) {
+                console.warn('Invalid ACADIA checkbox structure in field (ID: ' + acadiaHtmlBlockFieldId + ')', {
+                    feature: feature,
+                    inputExists: $input.length > 0,
+                    labelExists: $label.length > 0,
+                    divHtml: $div.html(),
+                    inputId: $input.attr('id'),
+                    labelClasses: $label.attr('class'),
+                    parentClasses: $div.attr('class')
+                });
+                return;
+            }
+            
+            var matchedFeature = Object.keys(featureDescriptions).find(function(key) {
+                return fuzzyMatch(key, feature, model, feature);
+            });
+            if (matchedFeature && !$div.find('.feature-info-icon[data-feature="' + String(matchedFeature) + '"]').length) {
+                $label.prepend('<span class="feature-info-icon" data-feature="' + String(matchedFeature) + '">i</span>');
+                console.log('Prepended info icon before ACADIA feature: ' + feature + ', matched: ' + matchedFeature);
+            }
+        });
     } else {
         // For other models, use existing logic
         checkboxField.find('.gfield_checkbox > div, .gfield-choice-wrapper').each(function() {
@@ -1762,12 +1905,246 @@ function populateTerrainFeaturesAfterDescriptions() {
         });
     }
 
+    // Populate GMC Acadia features
+    var acadiaPopulated = false;
+    function populateAcadiaFeatures() {
+        console.log('=== populateAcadiaFeatures called ===');
+        console.log('Current acadiaPopulated flag:', acadiaPopulated);
+        console.log('Form ID:', formId);
+        console.log('acadiaHtmlBlockFieldId:', acadiaHtmlBlockFieldId);
+        
+        if (acadiaPopulated) {
+            console.log('Acadia features already populated, skipping');
+            return;
+        }
+
+        // Load acadia descriptions first if not already loaded
+        if (!acadiaFeatureDescriptions || Object.keys(acadiaFeatureDescriptions).length === 0) {
+            console.log('🚨 Acadia descriptions not loaded, loading first...');
+            // Load descriptions and then populate features
+            loadAcadiaFeatureDescriptions().then(function() {
+                console.log('✅ Descriptions loaded, now populating features...');
+                populateAcadiaFeaturesAfterDescriptions();
+            }).catch(function(error) {
+                console.error('❌ Failed to load descriptions:', error);
+                // Continue anyway with basic feature names
+                populateAcadiaFeaturesAfterDescriptions();
+            });
+            return;
+        }
+        
+        populateAcadiaFeaturesAfterDescriptions();
+    }
+
+    function populateAcadiaFeaturesAfterDescriptions() {
+        console.log('=== populateAcadiaFeaturesAfterDescriptions called ===');
+
+        var config = modelConfigs['ACADIA'];
+        if (!config) {
+            console.warn('Acadia configuration not found');
+            return;
+        }
+
+        var csvUrl = 'https://hutchinsonautoteam.com/gmcmodels/acadia.csv';
+        
+        console.log('Loading acadia features from:', csvUrl);
+        Papa.parse(csvUrl, {
+            download: true,
+            header: false,
+            skipEmptyLines: true,
+            complete: function(results) {
+                console.log('Acadia CSV parsed for population, rows: ' + results.data.length);
+                console.log('First few rows:', results.data.slice(0, 3));
+                
+                var categories = ['EXTERIOR', 'INTERIOR', 'MECHANICAL', 'SAFETY', 'PACKAGES'];
+                var featureGroups = {};
+                var currentCategory = null;
+                var features = [];
+
+                results.data.forEach(function(row, rowIndex) {
+                    if (row.length > 0) {
+                        var firstCell = row[0] ? row[0].trim() : '';
+                        if (firstCell.startsWith('TRIM LEVELS FOR {')) {
+                            if (currentCategory && features.length > 0) {
+                                featureGroups[currentCategory] = features;
+                                console.log('Stored category: ' + currentCategory + ' with ' + features.length + ' features');
+                            }
+                            currentCategory = firstCell.match(/\{(.+)\}/)[1];
+                            // Clean up features by removing extra quotes and trimming
+                            features = row.slice(1).filter(function(f) { return f && f.trim() !== ''; }).map(function(f) {
+                                // Ensure f is a string first (Papa Parse may convert numbers)
+                                var str = String(f);
+                                // Remove surrounding quotes if present
+                                var cleaned = str.trim();
+                                if (cleaned.startsWith('"') && cleaned.endsWith('"')) {
+                                    cleaned = cleaned.slice(1, -1);
+                                }
+                                // Handle double quotes inside the string (CSV escape format)
+                                cleaned = cleaned.replace(/""/g, '"');
+                                return cleaned;
+                            });
+                            console.log('Row ' + rowIndex + ': Parsed category: ' + currentCategory + ', features: ' + features.length);
+                            console.log('Features for ' + currentCategory + ':', features.slice(0, 5)); // Show first 5 features
+                            console.log('Raw features before cleaning:', row.slice(1, 6)); // Show raw features
+                        }
+                    }
+                });
+                if (currentCategory && features.length > 0) {
+                    featureGroups[currentCategory] = features;
+                    console.log('Final stored category: ' + currentCategory + ' with ' + features.length + ' features');
+                }
+
+                console.log('Feature groups summary:', Object.keys(featureGroups).map(function(cat) {
+                    return cat + ': ' + featureGroups[cat].length + ' features';
+                }));
+
+                if (Object.keys(featureGroups).length !== 5) {
+                    console.error('Expected 5 categories, found: ' + Object.keys(featureGroups).length);
+                    console.error('Found categories:', Object.keys(featureGroups));
+                    return;
+                }
+
+                console.log('Building HTML for acadia features...');
+                var html = '<div class="feature-groups">';
+                var globalIndex = 0;
+                categories.forEach(function(category) {
+                    var catFeatures = featureGroups[category] || [];
+                    console.log('Building HTML for category: ' + category + ' with ' + catFeatures.length + ' features');
+                    html += '<div class="feature-column"><h4>' + category + '</h4><div class="gfield_checkbox">';
+                    catFeatures.forEach(function(feature, index) {
+                        var uniqueId = 'choice_3_acadia_' + globalIndex;
+                        var inputName = 'input_acadia_' + globalIndex;
+                        var simpleValue = 'acadia_feature_' + globalIndex;
+                        
+                        // Initialize global feature mapping
+                        if (!window.acadiaFeatureMap) {
+                            window.acadiaFeatureMap = {};
+                        }
+                        window.acadiaFeatureMap[simpleValue] = feature;
+                        
+                        // Try to find the full feature name from acadia descriptions
+                        var fullFeatureName = feature;
+                        if (acadiaFeatureDescriptions && Object.keys(acadiaFeatureDescriptions).length > 0) {
+                            // First try exact match
+                            var exactMatch = acadiaFeatureDescriptions[String(feature).toUpperCase()];
+                            if (exactMatch) {
+                                fullFeatureName = feature; // Use original since we have exact match
+                                console.log('✅ Found exact match for:', feature);
+                            } else {
+                                // Try partial matching for backwards compatibility
+                                var matchedKey = Object.keys(acadiaFeatureDescriptions).find(function(key) {
+                                    return key.includes(String(feature).toUpperCase()) || String(feature).toUpperCase().includes(key);
+                                });
+                                if (matchedKey) {
+                                    fullFeatureName = matchedKey;
+                                    console.log('⚠️ Found partial match for:', feature, '→', matchedKey);
+                                } else {
+                                    console.log('❌ No match found for:', feature);
+                                }
+                            }
+                        }
+                        
+                        // Build HTML using simple string concatenation to avoid any quote issues
+                        var divStart = '<div class="gchoice gchoice_acadia_' + globalIndex + '">';
+                        var inputTag = '<input name="' + inputName + '" type="checkbox" value="' + simpleValue + '" data-category="' + category + '" id="' + uniqueId + '">';
+                        var labelTag = '<label for="' + uniqueId + '" id="label_acadia_' + globalIndex + '">' + fullFeatureName + '</label>';
+                        // Add feature info icon for acadia features - use full feature name for data-feature
+                        var infoIcon = '<span class="feature-info-icon acadia-info-icon" data-feature="' + String(fullFeatureName) + '" style="margin-left: 8px; cursor: pointer; color: #007cba; font-weight: bold; font-size: 16px; border: 1px solid #007cba; border-radius: 50%; width: 20px; height: 20px; display: inline-block; text-align: center; line-height: 18px; background-color: #f0f8ff;" title="Click for GMC Acadia feature description">ℹ</span>';
+                        var divEnd = '</div>';
+                        
+                        html += divStart + inputTag + labelTag + infoIcon + divEnd;
+                        globalIndex++;
+                    });
+                    html += '</div></div>';
+                });
+                html += '</div>';
+                
+                console.log('🔨 Generated HTML length:', html.length);
+                console.log('🔨 Generated HTML sample:', html.substring(0, 300) + '...');
+                
+                // Update HTML content
+                var htmlBlock = $('#field_' + formId + '_' + acadiaHtmlBlockFieldId);
+                if (htmlBlock.length) {
+                    console.log('Found HTML block, updating content...');
+                    htmlBlock.html(html);
+                    console.log('HTML block updated');
+                    
+                    // Mark as populated
+                    acadiaPopulated = true;
+                    console.log('✅ Acadia features populated successfully!');
+                    
+                    // Bind change events
+                    htmlBlock.find('input[type="checkbox"]').on('change', function() {
+                        var featureValue = this.value;
+                        var featureName = window.acadiaFeatureMap[featureValue];
+                        var category = $(this).data('category');
+                        console.log('ACADIA feature changed:', featureName, 'Category:', category, 'Checked:', this.checked);
+                    });
+
+                    htmlBlock.find('.feature-info-icon').off('click.featureInfo').on('click.featureInfo', function(e) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        var feature = $(this).attr('data-feature');
+                        console.log('=== ACADIA FEATURE INFO ICON CLICKED ===');
+                        console.log('Feature clicked:', feature);
+                        console.log('Feature type:', typeof feature);
+                        console.log('Feature length:', feature ? feature.length : 'undefined');
+                        console.log('Available acadia descriptions:', Object.keys(acadiaFeatureDescriptions));
+                        console.log('Total descriptions available:', Object.keys(acadiaFeatureDescriptions).length);
+                        console.log('All descriptions:', acadiaFeatureDescriptions);
+                        
+                        // Handle case where feature might be undefined or not a string
+                        if (!feature || typeof feature !== 'string') {
+                            console.error('Invalid feature:', feature);
+                            showFeatureDescription('Unknown Feature', 'Feature information not available');
+                            return;
+                        }
+                        
+                        console.log('Looking for feature (uppercase):', feature.toUpperCase());
+                        
+                        // Try exact match first
+                        var description = acadiaFeatureDescriptions[feature.toUpperCase()];
+                        
+                        // If no exact match, try partial matching
+                        if (!description) {
+                            console.log('No exact match found, trying partial matching...');
+                            var matchedKey = Object.keys(acadiaFeatureDescriptions).find(function(key) {
+                                // Check if the key contains the feature or vice versa
+                                return key.includes(feature.toUpperCase()) || feature.toUpperCase().includes(key);
+                            });
+                            if (matchedKey) {
+                                description = acadiaFeatureDescriptions[matchedKey];
+                                console.log('Found partial match:', matchedKey);
+                            }
+                        }
+                        
+                        // If still no match, provide fallback
+                        if (!description) {
+                            description = 'No GMC Acadia description available for ' + feature;
+                            console.log('No match found, using fallback description');
+                        }
+                        
+                        console.log('Found description:', description);
+                        console.log('=== END ACADIA FEATURE INFO DEBUG ===');
+                        
+                        showFeatureDescription(feature, description);
+                    });
+                } else {
+                    console.error('❌ HTML block not found for field ID:', acadiaHtmlBlockFieldId);
+                }
+            },
+            error: function(error) {
+                console.error('❌ Error parsing Acadia CSV:', error);
+            }
+        });
+    }
+
     // Bind click events for feature info icons with explicit propagation stop
     checkboxField.find('.feature-info-icon').off('click.featureInfo').on('click.featureInfo', function(e) {
         e.preventDefault();
         e.stopPropagation();
         var feature = $(this).attr('data-feature');
-        // Use GMC Terrain descriptions for TERRAIN model, otherwise use KIA descriptions
+        // Use GMC Terrain descriptions for TERRAIN model, GMC Acadia descriptions for ACADIA model, otherwise use KIA descriptions
         var description;
         if (model === 'TERRAIN') {
             console.log('TERRAIN model detected, using GMC descriptions');
@@ -1798,6 +2175,39 @@ function populateTerrainFeaturesAfterDescriptions() {
             // If still no match, provide fallback
             if (!description) {
                 description = 'No GMC Terrain description available for ' + featureString;
+                console.log('No match found, using fallback description');
+            }
+            
+            console.log('Found description:', description);
+        } else if (model === 'ACADIA') {
+            console.log('ACADIA model detected, using GMC descriptions');
+            console.log('Feature to lookup:', feature);
+            
+            // Convert feature to string to avoid toUpperCase errors
+            var featureString = String(feature || '');
+            console.log('Feature as string:', featureString);
+            console.log('Feature uppercase:', featureString.toUpperCase());
+            console.log('Available acadia descriptions:', Object.keys(acadiaFeatureDescriptions));
+            
+            // Try exact match first
+            description = acadiaFeatureDescriptions[featureString.toUpperCase()];
+            
+            // If no exact match, try partial matching
+            if (!description) {
+                console.log('No exact match found, trying partial matching...');
+                var matchedKey = Object.keys(acadiaFeatureDescriptions).find(function(key) {
+                    // Check if the key contains the feature or vice versa
+                    return key.includes(featureString.toUpperCase()) || featureString.toUpperCase().includes(key);
+                });
+                if (matchedKey) {
+                    description = acadiaFeatureDescriptions[matchedKey];
+                    console.log('Found partial match:', matchedKey);
+                }
+            }
+            
+            // If still no match, provide fallback
+            if (!description) {
+                description = 'No GMC Acadia description available for ' + featureString;
                 console.log('No match found, using fallback description');
             }
             
@@ -2600,9 +3010,17 @@ function initFormBindings() {
                                     populateTerrainFeatures();
                                     console.log('terrainPopulated after call:', terrainPopulated);
                                     updateTrimLevels('TERRAIN');
+                                } else if (input.val() === 'ACADIA' && input.is(':checked')) {
+                                    console.log('🚗 ACADIA selected via radio button - calling populateAcadiaFeatures');
+                                    console.log('Current time:', new Date().toISOString());
+                                    console.log('acadiaPopulated before call:', acadiaPopulated);
+                                    populateAcadiaFeatures();
+                                    console.log('acadiaPopulated after call:', acadiaPopulated);
+                                    updateTrimLevels('ACADIA');
                                 } else if (input.is(':checked')) {
-                                    console.log('Non-TERRAIN GMC model selected: ' + input.val());
+                                    console.log('Non-TERRAIN/ACADIA GMC model selected: ' + input.val());
                                     terrainPopulated = false;
+                                    acadiaPopulated = false;
                                 }
                             }
                         }
@@ -2652,9 +3070,17 @@ function initFormBindings() {
                              populateTerrainFeatures();
                              console.log('terrainPopulated after call:', terrainPopulated);
                              updateTrimLevels('TERRAIN');
+                         } else if ($(this).val() === 'ACADIA' && $(this).is(':checked')) {
+                             console.log('🚗 ACADIA selected via delegated radio button - calling populateAcadiaFeatures');
+                             console.log('Current time:', new Date().toISOString());
+                             console.log('acadiaPopulated before call:', acadiaPopulated);
+                             populateAcadiaFeatures();
+                             console.log('acadiaPopulated after call:', acadiaPopulated);
+                             updateTrimLevels('ACADIA');
                          } else if ($(this).is(':checked')) {
-                             console.log('Non-TERRAIN GMC model selected via delegated: ' + $(this).val());
+                             console.log('Non-TERRAIN/ACADIA GMC model selected via delegated: ' + $(this).val());
                              terrainPopulated = false;
+                             acadiaPopulated = false;
                          }
                      }
                 }
@@ -2802,9 +3228,14 @@ function initFormBindings() {
                 console.log('TERRAIN radio button detected, calling populateTerrainFeatures');
                 populateTerrainFeatures();
                 updateTrimLevels('TERRAIN');
+            } else if ($(this).val() === 'ACADIA' && $(this).is(':checked')) {
+                console.log('ACADIA radio button detected, calling populateAcadiaFeatures');
+                populateAcadiaFeatures();
+                updateTrimLevels('ACADIA');
             } else if ($(this).is(':checked')) {
-                console.log('Non-TERRAIN GMC model selected, resetting terrain');
+                console.log('Non-TERRAIN/ACADIA GMC model selected, resetting');
                 terrainPopulated = false;
+                acadiaPopulated = false;
             }
         });
 
@@ -2827,7 +3258,17 @@ function initFormBindings() {
                             } else {
                                 console.log('TERRAIN radio button not checked or not found');
                             }
-                        } else if (model !== 'TERRAIN') {
+                        } else if (model === 'ACADIA') {
+                            // Check if ACADIA radio button is selected
+                            var acadiaRadio = $('#field_' + formId + '_' + gmcModelFieldId + ' input[type="radio"][value="ACADIA"]');
+                            if (acadiaRadio.length && acadiaRadio.is(':checked')) {
+                                console.log('ACADIA radio button is checked, populating features');
+                                populateAcadiaFeatures();
+                                updateTrimLevels(model);
+                            } else {
+                                console.log('ACADIA radio button not checked or not found');
+                            }
+                        } else if (model !== 'TERRAIN' && model !== 'ACADIA') {
                             updateTrimLevels(model);
                         }
                     });
@@ -2856,7 +3297,17 @@ function initFormBindings() {
                             } else {
                                 console.log('TERRAIN radio button not checked or not found');
                             }
-                        } else if (model !== 'TERRAIN') {
+                        } else if (model === 'ACADIA') {
+                            // Check if ACADIA radio button is selected
+                            var acadiaRadio = $('#field_' + formId + '_' + gmcModelFieldId + ' input[type="radio"][value="ACADIA"]');
+                            if (acadiaRadio.length && acadiaRadio.is(':checked')) {
+                                console.log('ACADIA radio button is checked, populating features');
+                                populateAcadiaFeatures();
+                                updateTrimLevels(model);
+                            } else {
+                                console.log('ACADIA radio button not checked or not found');
+                            }
+                        } else if (model !== 'TERRAIN' && model !== 'ACADIA') {
                             updateTrimLevels(model);
                         }
                     });
@@ -4844,6 +5295,7 @@ function showVehicleInfo(isKiaField) {
 
     loadFeatureDescriptions();
     loadTerrainFeatureDescriptions();
+    loadAcadiaFeatureDescriptions();
 initFormBindings();
 updateSelectedName();
 
@@ -5058,7 +5510,33 @@ window.reloadTerrainDescriptions = function() {
     loadTerrainFeatureDescriptions();
 };
 
-console.log('Debug functions available: testTerrainDebug(), forcePopulateTerrainFeatures(), createTerrainCheckboxesManually(), checkTerrainState(), testTerrainDescriptions(), reloadTerrainDescriptions()');
+// Force reload acadia descriptions
+window.reloadAcadiaDescriptions = function() {
+    console.log('🔄 Forcing reload of acadia descriptions...');
+    acadiaFeatureDescriptions = {};
+    loadAcadiaFeatureDescriptions();
+};
+
+// Force populate acadia features
+window.forcePopulateAcadiaFeatures = function() {
+    console.log('🔄 Forcing populate of acadia features...');
+    acadiaPopulated = false;
+    populateAcadiaFeatures();
+};
+
+// Test acadia descriptions
+window.testAcadiaDescriptions = function() {
+    console.log('🧪 Testing acadia descriptions...');
+    console.log('Number of descriptions:', Object.keys(acadiaFeatureDescriptions).length);
+    console.log('First 5 descriptions:', Object.keys(acadiaFeatureDescriptions).slice(0, 5));
+    console.log('Sample description:', Object.keys(acadiaFeatureDescriptions)[0], ':', acadiaFeatureDescriptions[Object.keys(acadiaFeatureDescriptions)[0]]);
+    
+    // Reload descriptions
+    console.log('Reloading acadia descriptions...');
+    loadAcadiaFeatureDescriptions();
+};
+
+console.log('Debug functions available: testTerrainDebug(), forcePopulateTerrainFeatures(), createTerrainCheckboxesManually(), checkTerrainState(), testTerrainDescriptions(), reloadTerrainDescriptions(), forcePopulateAcadiaFeatures(), testAcadiaDescriptions(), reloadAcadiaDescriptions()');
 
 // GLOBAL RADIO BUTTON LISTENER FOR DEBUGGING
 $(document).on('change', 'input[type="radio"]', function() {

--- a/WORKING AS OF 7 12.HTML
+++ b/WORKING AS OF 7 12.HTML
@@ -819,15 +819,27 @@ jQuery(document).ready(function($) {
             // Parse the new CSV format with curly braces: {FEATURE_NAME :Description}
             terrainFeatureDescriptions = {};
             
-            // Find all entries enclosed in curly braces
+            // Find all entries enclosed in curly braces - more robust regex
             var curlyBraceRegex = /\{([^}]+)\}/g;
-            var matches = csvText.match(curlyBraceRegex);
+            var matches = [];
+            var match;
             
-            if (matches) {
-                matches.forEach(function(match, index) {
+            // Use exec to get all matches with better error handling
+            while ((match = curlyBraceRegex.exec(csvText)) !== null) {
+                matches.push(match[0]);
+            }
+            
+            console.log('Total curly brace matches found:', matches.length);
+            console.log('First few matches:', matches.slice(0, 3));
+            
+            if (matches.length > 0) {
+                matches.forEach(function(matchText, index) {
                     try {
-                        // Remove the curly braces and split on the first colon
-                        var content = match.substring(1, match.length - 1); // Remove { and }
+                        // Remove the curly braces
+                        var content = matchText.substring(1, matchText.length - 1); // Remove { and }
+                        console.log('Processing match ' + index + ':', content.substring(0, 100) + '...');
+                        
+                        // Look for ' :' (space + colon) separator
                         var colonIndex = content.indexOf(' :');
                         
                         if (colonIndex !== -1) {
@@ -837,31 +849,47 @@ jQuery(document).ready(function($) {
                             if (feature && description) {
                                 // Store with case-insensitive key for matching
                                 terrainFeatureDescriptions[feature.toUpperCase()] = description;
-                                console.log('Loaded GMC Terrain description for:', feature);
+                                console.log('✅ Loaded GMC Terrain description for:', feature);
                             } else {
-                                console.warn('Empty feature or description:', { feature: feature, description: description.substring(0, 50) + '...' });
+                                console.warn('❌ Empty feature or description:', { 
+                                    feature: feature, 
+                                    description: description.substring(0, 50) + '...',
+                                    hasFeature: !!feature,
+                                    hasDescription: !!description
+                                });
                             }
                         } else {
-                            console.warn('Could not find colon separator in:', content.substring(0, 100));
+                            console.warn('❌ Could not find " :" separator in:', content.substring(0, 100));
+                            // Try alternative separators
+                            var altColonIndex = content.indexOf(':');
+                            if (altColonIndex !== -1) {
+                                var altFeature = content.substring(0, altColonIndex).trim();
+                                var altDescription = content.substring(altColonIndex + 1).trim();
+                                if (altFeature && altDescription) {
+                                    terrainFeatureDescriptions[altFeature.toUpperCase()] = altDescription;
+                                    console.log('✅ Loaded GMC Terrain description (alt format) for:', altFeature);
+                                }
+                            }
                         }
                     } catch (error) {
-                        console.error('Error parsing terrain description entry:', error, match.substring(0, 100));
+                        console.error('❌ Error parsing terrain description entry:', error, matchText.substring(0, 100));
                     }
                 });
             } else {
-                console.warn('No curly brace entries found in CSV');
+                console.warn('❌ No curly brace entries found in CSV');
+                console.log('CSV content preview:', csvText.substring(0, 1000));
             }
             
             console.log('GMC Terrain Feature Descriptions loaded, features:', Object.keys(terrainFeatureDescriptions).length);
             console.log('Sample features loaded:', Object.keys(terrainFeatureDescriptions).slice(0, 5));
             console.log('All terrain features loaded:', Object.keys(terrainFeatureDescriptions));
             if (Object.keys(terrainFeatureDescriptions).length === 0) {
-                console.warn('No GMC Terrain descriptions were parsed from CSV');
+                console.warn('❌ No GMC Terrain descriptions were parsed from CSV');
             } else {
-                console.log('SUCCESS: GMC Terrain descriptions loaded successfully!');
+                console.log('✅ SUCCESS: GMC Terrain descriptions loaded successfully!');
             }
         }).catch(function(error) {
-            console.error('Fetch error for GMC Terrain Feature Descriptions:', error.message);
+            console.error('❌ Fetch error for GMC Terrain Feature Descriptions:', error.message);
             terrainFeatureDescriptions = {};
         });
     }
@@ -1259,8 +1287,29 @@ jQuery(document).ready(function($) {
                     }
                     
                     console.log('Looking for feature (uppercase):', feature.toUpperCase());
-                    // Use GMC Terrain descriptions instead of KIA descriptions (case-insensitive)
-                    var description = terrainFeatureDescriptions[feature.toUpperCase()] || 'No GMC Terrain description available for ' + feature;
+                    
+                    // Try exact match first
+                    var description = terrainFeatureDescriptions[feature.toUpperCase()];
+                    
+                    // If no exact match, try partial matching
+                    if (!description) {
+                        console.log('No exact match found, trying partial matching...');
+                        var matchedKey = Object.keys(terrainFeatureDescriptions).find(function(key) {
+                            // Check if the key contains the feature or vice versa
+                            return key.includes(feature.toUpperCase()) || feature.toUpperCase().includes(key);
+                        });
+                        if (matchedKey) {
+                            description = terrainFeatureDescriptions[matchedKey];
+                            console.log('Found partial match:', matchedKey);
+                        }
+                    }
+                    
+                    // If still no match, provide fallback
+                    if (!description) {
+                        description = 'No GMC Terrain description available for ' + feature;
+                        console.log('No match found, using fallback description');
+                    }
+                    
                     console.log('Found description:', description);
                     console.log('=== END TERRAIN FEATURE INFO DEBUG ===');
                     showFeatureDescription(feature, description);
@@ -1678,7 +1727,29 @@ jQuery(document).ready(function($) {
             console.log('Feature to lookup:', feature);
             console.log('Feature uppercase:', feature.toUpperCase());
             console.log('Available terrain descriptions:', Object.keys(terrainFeatureDescriptions));
-            description = terrainFeatureDescriptions[feature.toUpperCase()] || 'No description available for ' + feature;
+            
+            // Try exact match first
+            description = terrainFeatureDescriptions[feature.toUpperCase()];
+            
+            // If no exact match, try partial matching
+            if (!description) {
+                console.log('No exact match found, trying partial matching...');
+                var matchedKey = Object.keys(terrainFeatureDescriptions).find(function(key) {
+                    // Check if the key contains the feature or vice versa
+                    return key.includes(feature.toUpperCase()) || feature.toUpperCase().includes(key);
+                });
+                if (matchedKey) {
+                    description = terrainFeatureDescriptions[matchedKey];
+                    console.log('Found partial match:', matchedKey);
+                }
+            }
+            
+            // If still no match, provide fallback
+            if (!description) {
+                description = 'No GMC Terrain description available for ' + feature;
+                console.log('No match found, using fallback description');
+            }
+            
             console.log('Found description:', description);
         } else {
             description = featureDescriptions[feature] || 'No description available for ' + feature;
@@ -4891,7 +4962,45 @@ window.checkTerrainState = function() {
     console.log('Selected model:', selectedModel);
 };
 
-console.log('Debug functions available: testTerrainDebug(), forcePopulateTerrainFeatures(), createTerrainCheckboxesManually(), checkTerrainState()');
+// Manual function to test terrain descriptions parsing
+window.testTerrainDescriptions = function() {
+    console.log('=== Testing Terrain Descriptions ===');
+    console.log('terrainFeatureDescriptions object:', terrainFeatureDescriptions);
+    console.log('Number of descriptions loaded:', Object.keys(terrainFeatureDescriptions).length);
+    console.log('Available features:', Object.keys(terrainFeatureDescriptions));
+    
+    // Test with sample content
+    var testContent = '{19" TECHNICAL GRAY MACHINED FACE ALUMINUM WHEELS :These 19-inch aluminum wheels feature a sophisticated Technical Gray finish with a machined face, giving them a sleek, modern appearance.}';
+    console.log('Testing with sample content:', testContent);
+    
+    var curlyBraceRegex = /\{([^}]+)\}/g;
+    var matches = [];
+    var match;
+    
+    while ((match = curlyBraceRegex.exec(testContent)) !== null) {
+        matches.push(match[0]);
+    }
+    
+    console.log('Matches found:', matches.length);
+    if (matches.length > 0) {
+        var content = matches[0].substring(1, matches[0].length - 1);
+        var colonIndex = content.indexOf(' :');
+        console.log('Content:', content);
+        console.log('Colon index:', colonIndex);
+        if (colonIndex !== -1) {
+            var feature = content.substring(0, colonIndex).trim();
+            var description = content.substring(colonIndex + 2).trim();
+            console.log('Parsed feature:', feature);
+            console.log('Parsed description:', description.substring(0, 100) + '...');
+        }
+    }
+    
+    // Reload descriptions
+    console.log('Reloading terrain descriptions...');
+    loadTerrainFeatureDescriptions();
+};
+
+console.log('Debug functions available: testTerrainDebug(), forcePopulateTerrainFeatures(), createTerrainCheckboxesManually(), checkTerrainState(), testTerrainDescriptions()');
 
 // GLOBAL RADIO BUTTON LISTENER FOR DEBUGGING
 $(document).on('change', 'input[type="radio"]', function() {


### PR DESCRIPTION
Ensure feature descriptions for numeric-looking features display correctly.

The `.data()` method was converting `data-feature` attribute values (like "19") from strings to numbers, preventing matches with string keys in the feature descriptions. Using `.attr()` retrieves the raw string value, resolving the mismatch.